### PR TITLE
Add feature for re-sending validation email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Changelog
 
-####v1.0.0
+###v1.0.1
+#### Added
+- Implemented form for re-sending validation emails 
+
+###v1.0.0
 #### Added
 - Log in functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 ## Changelog
 
-###v1.0.1
+### v1.0.1
 #### Added
-- Implemented form for re-sending validation emails 
+- Implemented form for re-sending validation emails
 
-###v1.0.0
+### v1.0.0
 #### Added
 - Log in functionality
 
-###v0.0.2
+### v0.0.2
 #### Added
 - Rendered list of libraries
 - Rendered details about each library
 - Implemented functionality for editing library stage and registry stage
 - Made library details more readable by implementing an accessible Tabs component
 
-###v0.0.1
+### v0.0.1
 #### Added
 - Set up the interface

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -327,6 +327,30 @@ describe("actions", () => {
     });
   });
 
+  describe("email", () => {
+    it("sends an email", async () => {
+      const dispatch = stub();
+      const formData = new (window as any).FormData();
+      formData.append("uuid", "abc");
+
+      const fetchMock = stub().returns(new Promise<any>((update, reject) => {
+        update({ status: 200 });
+      }));
+      fetch = fetchMock;
+
+      await actions.email(formData)(dispatch);
+      expect(dispatch.callCount).to.equal(2);
+
+      expect(dispatch.args[0][0].type).to.equal("EMAIL_REQUEST");
+      expect(dispatch.args[1][0].type).to.equal("EMAIL_SUCCESS");
+
+      expect(fetchMock.callCount).to.equal(1);
+      expect(fetchMock.args[0][0]).to.equal("/admin/libraries/email");
+      expect(fetchMock.args[0][1].method).to.equal("POST");
+      expect(fetchMock.args[0][1].body).to.equal(formData);
+    });
+  });
+
   describe("logIn", () => {
     it("submits credentials", async () => {
       const dispatch = stub();

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -13,6 +13,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly GET_ALL_LIBRARIES = "GET_ALL_LIBRARIES";
   static readonly GET_ONE_LIBRARY = "GET_ONE_LIBRARY";
 
+  static readonly EMAIL = "EMAIL";
   static readonly EDIT_STAGES = "EDIT_STAGES";
 
   static readonly LOG_IN = "LOG_IN";
@@ -145,6 +146,11 @@ export default class ActionCreator extends BaseActionCreator {
   fetchLibrary(uuid: string) {
     let url = "/admin/libraries/" + uuid;
     return this.fetchJSON<LibraryData>(ActionCreator.GET_ONE_LIBRARY, url).bind(this);
+  }
+
+  email(data: FormData) {
+    let url = "/admin/libraries/email";
+    return this.postForm(ActionCreator.EMAIL, url, data).bind(this);
   }
 
   editStages(data: FormData) {

--- a/src/components/EmailForm.tsx
+++ b/src/components/EmailForm.tsx
@@ -37,18 +37,17 @@ export class EmailForm extends React.Component<EmailFormProps, EmailFormState> {
 
   async sendEmail(data: FormData): Promise<void> {
     await this.props.email(data);
-    this.setState({ sent: true });
+    this.setState({ sent: !this.props.error });
   }
 
   render(): JSX.Element {
-    let disabled = false;
-    let icon = this.state.sent ? <CheckSoloIcon iconId="1" /> : null;
+    let icon = this.state.sent ? <CheckSoloIcon /> : null;
     let hasEmail = !!this.props.library.urls_and_contact.contact_email;
     let alreadyValidated = this.props.library.urls_and_contact.validated !== "Not validated";
 
     let buttonText = hasEmail ? "Send Validation Email" : "No email address configured";
     let buttonContent = <span>{buttonText}{icon}</span>;
-    let infoText = alreadyValidated && !this.state.sent && !this.props.error && "Already validated";
+    let infoText = (alreadyValidated && !this.state.sent && !this.props.error) ? "Already validated" : null;
     let successText = `Validation email successfully sent to ${this.props.library.urls_and_contact.contact_email}`;
 
     return (
@@ -60,7 +59,7 @@ export class EmailForm extends React.Component<EmailFormProps, EmailFormState> {
           onSubmit={this.sendEmail}
           buttonContent={buttonContent}
           disableButton={!hasEmail}
-          infoText={alreadyValidated ? infoText : null}
+          infoText={infoText}
           errorText={this.props.error ? this.props.error.response : null}
           successText={this.state.sent ? successText : null}
         />

--- a/src/components/EmailForm.tsx
+++ b/src/components/EmailForm.tsx
@@ -1,0 +1,89 @@
+import * as React from "react";
+import Form from "./reusables/Form";
+import { connect } from "react-redux";
+import ActionCreator from "../actions";
+import { FetchErrorData } from "opds-web-client/lib/interfaces";
+import { Store } from "redux";
+import { State } from "../reducers/index";
+import { LibraryData } from "../interfaces";
+import { CheckSoloIcon } from "@nypl/dgx-svg-icons";
+
+export interface EmailFormState {
+  sent: boolean;
+}
+
+export interface EmailFormOwnProps {
+  library: LibraryData;
+  store: Store<State>;
+}
+
+export interface EmailFormDispatchProps {
+  email: (data: FormData) => Promise<void>;
+}
+
+export interface EmailFormStateProps {
+  error?: FetchErrorData;
+}
+
+export interface EmailFormProps extends EmailFormOwnProps, EmailFormDispatchProps, EmailFormStateProps {}
+
+export class EmailForm extends React.Component<EmailFormProps, EmailFormState> {
+
+  constructor(props) {
+    super(props);
+    this.sendEmail = this.sendEmail.bind(this);
+    this.state = { sent: false };
+  }
+
+  async sendEmail(data: FormData): Promise<void> {
+    await this.props.email(data);
+    this.setState({ sent: true });
+  }
+
+  render(): JSX.Element {
+    let disabled = false;
+    let icon = this.state.sent ? <CheckSoloIcon iconId="1" /> : null;
+    let hasEmail = !!this.props.library.urls_and_contact.contact_email;
+    let alreadyValidated = this.props.library.urls_and_contact.validated !== "Not validated";
+
+    let buttonText = hasEmail ? "Send Validation Email" : "No email address configured";
+    let buttonContent = <span>{buttonText}{icon}</span>;
+    let infoText = alreadyValidated && !this.state.sent && !this.props.error && "Already validated";
+    let successText = `Validation email successfully sent to ${this.props.library.urls_and_contact.contact_email}`;
+
+    return (
+        <Form
+          className="validation"
+          hiddenName="uuid"
+          hiddenValue={this.props.library.uuid}
+          title="Validation"
+          onSubmit={this.sendEmail}
+          buttonContent={buttonContent}
+          disableButton={!hasEmail}
+          infoText={alreadyValidated ? infoText : null}
+          errorText={this.props.error ? this.props.error.response : null}
+          successText={this.state.sent ? successText : null}
+        />
+    );
+  }
+}
+
+function mapStateToProps(state: State, ownProps: EmailFormOwnProps) {
+  return {
+    error: state.email && (state.email.formError || state.email.fetchError)
+  };
+}
+
+function mapDispatchToProps(dispatch: Function, ownProps: EmailFormOwnProps) {
+  let actions = new ActionCreator(null);
+  return {
+    email: (data: FormData) => dispatch(actions.email(data)),
+  };
+}
+
+const ConnectedEmailForm = connect<EmailFormStateProps, EmailFormDispatchProps, EmailFormOwnProps>(
+  mapStateToProps,
+  mapDispatchToProps
+)(EmailForm);
+
+export default ConnectedEmailForm;

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -80,7 +80,7 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
     let libraryStage = this.props.fullLibrary.stages.library_stage;
     let registryStage = this.props.fullLibrary.stages.registry_stage;
     this.props.updateColor([libraryStage, registryStage]);
-    this.setState(Object.assign(this.state, { libraryStage, registryStage }));
+    this.setState({ libraryStage, registryStage });
   }
 
   render(): JSX.Element {

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -7,6 +7,7 @@ import { State } from "../reducers/index";
 import LibraryDetailItem from "./LibraryDetailItem";
 import LibraryStageItem from "./LibraryStageItem";
 import Form from "./reusables/Form";
+import EmailForm from "./EmailForm";
 import Tabs from "./reusables/Tabs";
 
 export interface LibraryDetailPageDispatchProps {
@@ -40,7 +41,7 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
     this.renderStages = this.renderStages.bind(this);
     this.state = {
       libraryStage: this.props.library.stages.library_stage,
-      registryStage: this.props.library.stages.registry_stage
+      registryStage: this.props.library.stages.registry_stage,
     };
   }
 
@@ -48,7 +49,7 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
 
     // Only create LibraryDetailItems for fields which actually have a value.
     let fields = Object.keys(category).filter(label => category[label]).map(label =>
-      <LibraryDetailItem key={label} label={label} value={category[label]} />
+      <LibraryDetailItem key={label} label={label} value={`${category[label]}`} />
     );
 
     return (
@@ -79,7 +80,7 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
     let libraryStage = this.props.fullLibrary.stages.library_stage;
     let registryStage = this.props.fullLibrary.stages.registry_stage;
     this.props.updateColor([libraryStage, registryStage]);
-    this.setState({ libraryStage, registryStage });
+    this.setState(Object.assign(this.state, { libraryStage, registryStage }));
   }
 
   render(): JSX.Element {
@@ -101,6 +102,8 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
     return(
       <div>
         { this.renderStages() }
+        <hr></hr>
+        <EmailForm store={this.props.store} library={library} />
         <hr></hr>
         <div className="detail-content">
           <Tabs items={tabItems}/>

--- a/src/components/__tests__/EmailForm-test.tsx
+++ b/src/components/__tests__/EmailForm-test.tsx
@@ -119,6 +119,21 @@ describe("EmailForm", () => {
     expect(wrapper.state()["sent"]).to.be.true;
   });
 
+  it("does not set 'sent' to true if there is an error", async () => {
+    expect(wrapper.state()["sent"]).to.be.false;
+    wrapper.find("button").simulate("click");
+
+
+    const pause = (): Promise<void> => {
+      return new Promise<any>((resolve, reject) => {
+        reject({ message: "email failure" });
+      });
+    };
+
+    expect(wrapper.state()["sent"]).to.be.false;
+    expect(wrapper.find("button").find("svg").length).to.equal(0);
+  });
+
   it("displays a success message", () => {
     let successMessage = wrapper.find(".alert-success");
     expect(successMessage.length).to.equal(0);

--- a/src/components/__tests__/EmailForm-test.tsx
+++ b/src/components/__tests__/EmailForm-test.tsx
@@ -1,0 +1,144 @@
+import { expect } from "chai";
+import * as Sinon from "sinon";
+import * as Enzyme from "enzyme";
+import * as React from "react";
+import buildStore from "../../store";
+import { EmailForm } from "../EmailForm";
+
+describe("EmailForm", () => {
+  let wrapper: Enzyme.CommonWrapper<any, any, {}>;
+  let store;
+  let email: Sinon.SinonSpy;
+
+  beforeEach(() => {
+    let library = {
+      uuid: "UUID1",
+      basic_info: {
+        "name": "Test Library 1",
+        "short_name": "lib1",
+        "description": undefined
+      },
+      urls_and_contact: {
+        "authentication_url": "auth1",
+        "contact_email": "email1",
+        "opds_url": "opds1",
+        "web_url": "web1",
+        "validated": "Not validated"
+      },
+      stages: {
+        "library_stage": "production",
+        "registry_stage": "testing"
+      }
+    };
+    store = buildStore();
+    email = Sinon.stub();
+    wrapper = Enzyme.mount(
+      <EmailForm store={store} library={library} email={email}/>
+    );
+  });
+
+  it("renders a form with a title, a hidden value, and a button", () => {
+    expect(wrapper.find(".validation").length).to.equal(1);
+
+    let title = wrapper.find(".form-title");
+    expect(title.length).to.equal(1);
+    expect(title.text()).to.equal("Validation");
+
+    let hiddenInput = wrapper.find("[type='hidden']");
+    expect(hiddenInput.length).to.equal(1);
+    expect(hiddenInput.prop("name")).to.equal("uuid");
+    expect(hiddenInput.prop("value")).to.equal("UUID1");
+
+    let button = wrapper.find("button");
+    expect(button.length).to.equal(1);
+  });
+
+  it("displays the correct button content", () => {
+    let button = wrapper.find("button");
+    expect(button.text()).to.contain("Send Validation Email");
+    expect(button.prop("disabled")).not.to.be.true;
+
+    let library = wrapper.prop("library");
+    let validated = Object.assign(library.urls_and_contact, { "validated": "validation time" });
+    wrapper.setProps({ library: Object.assign(library, { urls_and_contact: validated })});
+    button = wrapper.find("button");
+    expect(button.text()).to.contain("Send Validation Email");
+    expect(button.prop("disabled")).not.to.be.true;
+
+    let noEmail = Object.assign(library.urls_and_contact, { contact_email: null });
+    wrapper.setProps({ library: Object.assign(library, { urls_and_contact: noEmail })});
+    button = wrapper.find("button");
+    expect(button.text()).to.equal("No email address configured");
+    expect(button.prop("disabled")).to.be.true;
+  });
+
+  it("displays the correct button icon", () => {
+    let icon = wrapper.find("button").find("svg");
+    expect(icon.length).to.equal(0);
+
+    wrapper.setState({ sent: true });
+
+    icon = wrapper.find("button").find("svg");
+    expect(icon.length).to.equal(1);
+    expect(icon.hasClass("check-solo-icon")).to.be.true;
+  });
+
+  it("displays an info message", () => {
+    let info = wrapper.find(".alert-info");
+    expect(info.length).to.equal(0);
+
+    let library = wrapper.prop("library");
+    let validated = Object.assign(library.urls_and_contact, { "validated": "validation time" });
+    wrapper.setProps({ library: Object.assign(library, { urls_and_contact: validated })});
+
+    info = wrapper.find(".alert-info");
+    expect(info.length).to.equal(1);
+    expect(info.text()).to.equal("Already validated");
+
+    // Hide the info message if there's a success message or an error message to display instead
+    wrapper.setState({ sent: true });
+    info = wrapper.find(".alert-info");
+    expect(info.length).to.equal(0);
+
+    wrapper.setProps({ error: { response: "Failed to send email" } });
+    info = wrapper.find(".alert-info");
+    expect(info.length).to.equal(0);
+  });
+
+  it("submits on click", async () => {
+    expect(wrapper.state()["sent"]).to.be.false;
+    wrapper.find("button").simulate("click");
+    expect(email.callCount).to.equal(1);
+    expect(email.args[0][0].get("uuid")).to.equal("UUID1");
+
+    const pause = (): Promise<void> => {
+      return new Promise<void>(resolve => setTimeout(resolve, 0));
+    };
+    await pause();
+
+    expect(wrapper.state()["sent"]).to.be.true;
+  });
+
+  it("displays a success message", () => {
+    let successMessage = wrapper.find(".alert-success");
+    expect(successMessage.length).to.equal(0);
+
+    wrapper.setState({ sent: true });
+
+    successMessage = wrapper.find(".alert-success");
+    expect(successMessage.length).to.equal(1);
+    expect(successMessage.text()).to.equal("Validation email successfully sent to email1");
+  });
+
+  it("displays an error message", () => {
+    let errorMessage = wrapper.find(".alert-danger");
+    expect(errorMessage.length).to.equal(0);
+
+    wrapper.setProps({ error: { response: "Failed to send email" } });
+
+    errorMessage = wrapper.find(".alert-danger");
+    expect(errorMessage.length).to.equal(1);
+    expect(errorMessage.text()).to.equal("Failed to send email");
+  });
+
+});

--- a/src/components/__tests__/LibraryDetailPage-test.tsx
+++ b/src/components/__tests__/LibraryDetailPage-test.tsx
@@ -108,18 +108,18 @@ describe("LibraryDetailPage", () => {
     expect(infoLabels.indexOf("description")).to.equal(-1);
   });
 
-  it("should display a form", () => {
-    let form = wrapper.find("form");
-    expect(form.length).to.equal(1);
+  it("should display the edit form", () => {
+    let editForm = wrapper.find("form").at(0);
+    expect(editForm.length).to.equal(1);
 
-    let libraryStage = form.find("fieldset").at(0);
+    let libraryStage = editForm.find("fieldset").at(0);
     let libraryLegend = libraryStage.find("legend");
     let librarySelect = libraryStage.find("select");
     expect(libraryLegend.text()).to.equal("Library Stage");
     expect(librarySelect.props().name).to.equal("Library Stage");
     expect(librarySelect.props().defaultValue).to.equal("production");
 
-    let registryStage = form.find("fieldset").at(1);
+    let registryStage = editForm.find("fieldset").at(1);
     let registryLegend = registryStage.find("legend");
     let registrySelect = registryStage.find("select");
     expect(registryLegend.text()).to.equal("Registry Stage");
@@ -134,12 +134,12 @@ describe("LibraryDetailPage", () => {
       expect(options.at(2).props().value).to.equal("cancelled");
     });
 
-    let submitButton = form.find("button");
+    let submitButton = editForm.find("button");
     expect(submitButton.length).to.equal(1);
   });
 
-  it("should submit a form and fetch new data", async () => {
-    let form = wrapper.find("form");
+  it("should submit the edit form and fetch new data", async () => {
+    let form = wrapper.find("form").at(0);
     let submitButton = form.find("button");
     submitButton.simulate("click");
 
@@ -162,15 +162,20 @@ describe("LibraryDetailPage", () => {
     expect(updateColor.args[0][0][1]).to.equal("production");
   });
 
+  it("should display the validation form", () => {
+    let validationForm = wrapper.find("form").at(1);
+    expect(validationForm.length).to.equal(1);
+  });
+
   it("should re-render to reflect changes", async() => {
-    let form = wrapper.find("form");
+    let editForm = wrapper.find("form").at(0);
 
     expect(wrapper.state()["libraryStage"]).to.equal("production");
     expect(wrapper.state()["registryStage"]).to.equal("testing");
-    expect(form.find(".badge").at(0).props().className).to.contain("success");
-    expect(form.find(".badge").at(1).props().className).to.contain("warning");
+    expect(editForm.find(".badge").at(0).props().className).to.contain("success");
+    expect(editForm.find(".badge").at(1).props().className).to.contain("warning");
 
-    let saveButton = form.find("button");
+    let saveButton = editForm.find("button");
     saveButton.simulate("click");
     let newStages = { stages: { library_stage: "testing", registry_stage: "cancelled" } };
     let fullLibrary = Object.assign({}, (wrapper.props() as any)["library"], newStages);
@@ -183,7 +188,7 @@ describe("LibraryDetailPage", () => {
 
     expect(wrapper.state()["libraryStage"]).to.equal("testing");
     expect(wrapper.state()["registryStage"]).to.equal("cancelled");
-    expect(form.find(".badge").at(0).props().className).to.contain("warning");
-    expect(form.find(".badge").at(1).props().className).to.contain("danger");
+    expect(editForm.find(".badge").at(0).props().className).to.contain("warning");
+    expect(editForm.find(".badge").at(1).props().className).to.contain("danger");
   });
 });

--- a/src/components/reusables/Form.tsx
+++ b/src/components/reusables/Form.tsx
@@ -54,7 +54,7 @@ export default class Form extends React.Component<FormProps, void> {
           this.props.errorText && this.message(this.props.errorText, "danger")
         }
         {
-          this.props.successText && this.message(this.props.successText, "success")
+          this.props.successText && !this.props.errorText && this.message(this.props.successText, "success")
         }
         {
           this.props.infoText && this.message(this.props.infoText, "info")

--- a/src/components/reusables/Form.tsx
+++ b/src/components/reusables/Form.tsx
@@ -4,14 +4,18 @@ import SubmitButton from "./SubmitButton";
 import Fieldset from "./Fieldset";
 
 export interface FormProps {
-  content: Array<JSX.Element>;
+  content?: Array<JSX.Element>;
   onSubmit: any;
   title?: string;
   hiddenName?: string;
   hiddenValue?: string;
-  buttonText?: string;
+  buttonContent?: string | JSX.Element;
+  buttonClass?: string;
   className?: string;
   errorText?: string;
+  successText?: string;
+  infoText?: string;
+  disableButton?: boolean;
 }
 
 export default class Form extends React.Component<FormProps, void> {
@@ -19,7 +23,7 @@ export default class Form extends React.Component<FormProps, void> {
   constructor(props: FormProps) {
     super(props);
     this.submit = this.submit.bind(this);
-    this.errorMessage = this.errorMessage.bind(this);
+    this.message = this.message.bind(this);
   }
 
   componentDidUpdate() {
@@ -35,21 +39,25 @@ export default class Form extends React.Component<FormProps, void> {
     this.props.onSubmit(data);
   };
 
-  errorMessage(errorText: string): JSX.Element {
-    let error = (
-      <p className="alert alert-danger" role="alert" ref="errorMessage" tabIndex={-1}>
-        Error: {errorText}
+  message(text: string, type: string): JSX.Element {
+    return (
+      <p className={`alert alert-${type}`} role="alert" ref={`${type}Message`} tabIndex={-1}>
+        {text}
       </p>
     );
-
-    return error;
   }
 
   render(): JSX.Element {
     return(
       <form ref="form" className={`clearfix${this.props.className ? " " + this.props.className : ""}`}>
         {
-          this.props.errorText && this.errorMessage(this.props.errorText)
+          this.props.errorText && this.message(this.props.errorText, "danger")
+        }
+        {
+          this.props.successText && this.message(this.props.successText, "success")
+        }
+        {
+          this.props.infoText && this.message(this.props.infoText, "info")
         }
         { this.props.title &&
           <label className="form-title">{this.props.title}</label>
@@ -65,7 +73,9 @@ export default class Form extends React.Component<FormProps, void> {
         <br />
         <SubmitButton
           callback={this.submit}
-          text={this.props.buttonText && this.props.buttonText}
+          content={this.props.buttonContent && this.props.buttonContent}
+          className={this.props.buttonClass && this.props.buttonClass}
+          disabled={this.props.disableButton}
         />
       </form>
     );

--- a/src/components/reusables/LogInForm.tsx
+++ b/src/components/reusables/LogInForm.tsx
@@ -58,7 +58,7 @@ export class LogInForm extends React.Component<LogInFormProps, void> {
         className="log-in"
         title={title}
         content={[fieldset]}
-        buttonText="Log In"
+        buttonContent="Log In"
         onSubmit={this.submit}
         errorText={this.props.error && (this.props.error.response || "Invalid credentials")}
       />

--- a/src/components/reusables/SubmitButton.tsx
+++ b/src/components/reusables/SubmitButton.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 
 export interface SubmitButtonProps {
   callback: (event: __React.MouseEvent) => void;
-  text?: string;
+  content?: string | JSX.Element;
+  className?: string;
+  disabled?: boolean;
 }
 
 export default class SubmitButton extends React.Component<SubmitButtonProps, void> {
@@ -12,13 +14,15 @@ export default class SubmitButton extends React.Component<SubmitButtonProps, voi
   }
 
   render(): JSX.Element {
-   let text = this.props.text || "Submit";
+   let content = this.props.content || "Submit";
+   let className = this.props.className || "btn-default";
    return (
      <button
        type="submit"
-       className="btn btn-default"
+       className={`btn ${className}`}
        onClick={this.props.callback}
-    >{text}</button>
+       disabled={this.props.disabled || null}
+    >{content}</button>
    );
  }
 

--- a/src/components/reusables/__tests__/Form-test.tsx
+++ b/src/components/reusables/__tests__/Form-test.tsx
@@ -71,26 +71,71 @@ describe("Form", () => {
   });
 
   it("should optionally render an error message", () => {
-    let spyErrorMessage = Sinon.spy(wrapper.instance(), "errorMessage");
+    let spyMessage = Sinon.spy(wrapper.instance(), "message");
     let error = wrapper.find(".alert-danger");
-    expect(spyErrorMessage.callCount).to.equal(0);
+    expect(spyMessage.callCount).to.equal(0);
     expect(error.length).to.equal(0);
 
     wrapper.setProps({ errorText: "ERROR!" });
 
-    expect(spyErrorMessage.callCount).to.equal(1);
-    expect(spyErrorMessage.args[0][0]).to.equal("ERROR!");
+    expect(spyMessage.callCount).to.equal(1);
+    expect(spyMessage.args[0][0]).to.equal("ERROR!");
+    expect(spyMessage.args[0][1]).to.equal("danger");
     error = wrapper.find(".alert-danger");
     expect(error.length).to.equal(1);
-    expect(error.text()).to.equal("Error: ERROR!");
+    expect(error.text()).to.equal("ERROR!");
 
-    spyErrorMessage.restore();
+    spyMessage.restore();
+  });
+
+  it("should optionally render a success message", () => {
+    let spyMessage = Sinon.spy(wrapper.instance(), "message");
+    let success = wrapper.find(".alert-success");
+    expect(spyMessage.callCount).to.equal(0);
+    expect(success.length).to.equal(0);
+
+    wrapper.setProps({ successText: "SUCCESS!" });
+
+    expect(spyMessage.callCount).to.equal(1);
+    expect(spyMessage.args[0][0]).to.equal("SUCCESS!");
+    expect(spyMessage.args[0][1]).to.equal("success");
+    success = wrapper.find(".alert-success");
+    expect(success.length).to.equal(1);
+    expect(success.text()).to.equal("SUCCESS!");
+
+    spyMessage.restore();
+  });
+
+  it("should optionally render an info message", () => {
+    let spyMessage = Sinon.spy(wrapper.instance(), "message");
+    let info = wrapper.find(".alert-info");
+    expect(spyMessage.callCount).to.equal(0);
+    expect(info.length).to.equal(0);
+
+    wrapper.setProps({ infoText: "An info string" });
+
+    expect(spyMessage.callCount).to.equal(1);
+    expect(spyMessage.args[0][0]).to.equal("An info string");
+    expect(spyMessage.args[0][1]).to.equal("info");
+    info = wrapper.find(".alert-info");
+    expect(info.length).to.equal(1);
+    expect(info.text()).to.equal("An info string");
+
+    spyMessage.restore();
   });
 
   it("should render a SubmitButton", () => {
     let button = wrapper.find("SubmitButton");
     expect(button.length).to.equal(1);
     expect(button.props()["submit"]).to.equal((wrapper.instance() as any)["save"]);
+  });
+
+  it("should optionally props to the SubmitButton", () => {
+    wrapper.setProps({ buttonClass: "success", buttonContent: "testing...", disableButton: true });
+    let button = wrapper.find("SubmitButton");
+    expect(button.prop("className")).to.equal("success");
+    expect(button.text()).to.equal("testing...");
+    expect(button.prop("disabled")).to.be.true;
   });
 
   it("should call the onSave prop", () => {

--- a/src/components/reusables/__tests__/Form-test.tsx
+++ b/src/components/reusables/__tests__/Form-test.tsx
@@ -106,6 +106,27 @@ describe("Form", () => {
     spyMessage.restore();
   });
 
+  it("should not render a success message if it has an errorText prop", () => {
+    let spyMessage = Sinon.spy(wrapper.instance(), "message");
+    let success = wrapper.find(".alert-success");
+    let error = wrapper.find(".alert-danger");
+    expect(spyMessage.callCount).to.equal(0);
+    expect(success.length).to.equal(0);
+    expect(error.length).to.equal(0);
+
+    wrapper.setProps({ successText: "SUCCESS!", errorText: "blocking the successText!"});
+
+    expect(spyMessage.callCount).to.equal(1);
+    expect(spyMessage.args[0][1]).to.equal("danger");
+    expect(spyMessage.args[0][1]).not.to.equal("success");
+    success = wrapper.find(".alert-success");
+    error = wrapper.find(".alert-danger");
+    expect(success.length).to.equal(0);
+    expect(error.length).to.equal(1);
+
+    spyMessage.restore()
+  });
+
   it("should optionally render an info message", () => {
     let spyMessage = Sinon.spy(wrapper.instance(), "message");
     let info = wrapper.find(".alert-info");
@@ -130,7 +151,7 @@ describe("Form", () => {
     expect(button.props()["submit"]).to.equal((wrapper.instance() as any)["save"]);
   });
 
-  it("should optionally props to the SubmitButton", () => {
+  it("should optionally send props to the SubmitButton", () => {
     wrapper.setProps({ buttonClass: "success", buttonContent: "testing...", disableButton: true });
     let button = wrapper.find("SubmitButton");
     expect(button.prop("className")).to.equal("success");

--- a/src/components/reusables/__tests__/LogInForm-test.tsx
+++ b/src/components/reusables/__tests__/LogInForm-test.tsx
@@ -105,7 +105,7 @@ describe("LogInForm", () => {
       error = wrapper.find(".alert-danger");
       expect(form.prop("errorText")).to.equal("Invalid credentials");
       expect(error.length).to.equal(1);
-      expect(error.text()).to.equal("Error: Invalid credentials");
+      expect(error.text()).to.equal("Invalid credentials");
     });
     it("should render a specific error message", () => {
       let form = wrapper.find("form");
@@ -119,7 +119,7 @@ describe("LogInForm", () => {
       error = wrapper.find(".alert-danger");
       expect(form.prop("errorText")).to.equal("Custom error text!");
       expect(error.length).to.equal(1);
-      expect(error.text()).to.equal("Error: Custom error text!");
+      expect(error.text()).to.equal("Custom error text!");
     })
   });
 });

--- a/src/components/reusables/__tests__/SubmitButton-test.tsx
+++ b/src/components/reusables/__tests__/SubmitButton-test.tsx
@@ -22,7 +22,23 @@ describe("SubmitButton", () => {
   });
   it("optionally renders custom text", () => {
     expect(wrapper.text()).to.equal("Submit");
-    wrapper.setProps({ text: "Some other string" });
+    wrapper.setProps({ content: "Some other string" });
     expect(wrapper.text()).to.equal("Some other string");
+  });
+  it("optionally renders a component", () => {
+    let content = <span>Element!</span>;
+    wrapper.setProps({ content });
+    expect(wrapper.find("span").length).to.equal(1);
+    expect(wrapper.text()).to.equal("Element!");
+  });
+  it("optionally sets a className", () => {
+    expect(wrapper.prop("className")).to.equal("btn btn-default");
+    wrapper.setProps({ className: "custom-class" });
+    expect(wrapper.prop("className")).to.equal("btn custom-class");
+  });
+  it("optionally disables", () => {
+    expect(wrapper.find("[disabled=true]").length).to.equal(0);
+    wrapper.setProps({ disabled: true });
+    expect(wrapper.find("[disabled=true]").length).to.equal(1);
   });
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,5 @@
+import { FetchErrorData } from "opds-web-client/lib/interfaces";
+
 export interface LibraryData {
   uuid: string;
   basic_info: {
@@ -12,7 +14,8 @@ export interface LibraryData {
     authentication_url: string,
     contact_email: string,
     opds_url: string,
-    web_url: string
+    web_url: string,
+    validated?: string
   };
   stages: {
     library_stage: string,
@@ -26,4 +29,8 @@ export interface LibrariesData {
 
 export interface AdminData {
   username: string;
+}
+
+export interface EmailData {
+  error?: FetchErrorData;
 }

--- a/src/reducers/email.ts
+++ b/src/reducers/email.ts
@@ -1,0 +1,9 @@
+import { EmailData } from "../interfaces";
+import ActionCreator from "../actions";
+import createFetchEditReducer from "./createFetchEditReducer";
+import { RequestError } from "opds-web-client/lib/DataFetcher";
+
+
+export default createFetchEditReducer<EmailData>(
+  ActionCreator.EMAIL
+);

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -2,24 +2,27 @@ import { combineReducers } from "redux";
 import libraries from "./libraries";
 import library from "./library";
 import admin from "./admin";
+import email from "./email";
 
 import { FetchEditState } from "./createFetchEditReducer";
 
 import {
   LibrariesData,
   LibraryData,
+  EmailData,
   AdminData
 } from "../interfaces";
-
 
 export interface State {
   libraries: FetchEditState<LibrariesData>;
   library: FetchEditState<LibraryData>;
   admin: FetchEditState<AdminData>;
+  email: FetchEditState<EmailData>;
 }
 
 export default combineReducers<State>({
   libraries,
   library,
-  admin
+  admin,
+  email
 });

--- a/src/stylesheets/reusables/form.scss
+++ b/src/stylesheets/reusables/form.scss
@@ -28,7 +28,11 @@ form {
   &.validation {
     .form-title {
       text-align: left;
-      margin-left: .5em;
+      margin: 0;
+      width: 100%;
+    }
+    button.btn {
+      margin: 0;
     }
   }
 

--- a/src/stylesheets/reusables/form.scss
+++ b/src/stylesheets/reusables/form.scss
@@ -13,7 +13,7 @@ form {
     }
   }
 
-  &.log-in, &.validation {
+  &.log-in {
     button.btn {
       display: block;
       margin: auto;
@@ -22,6 +22,13 @@ form {
       &:hover {
         border-color: $gray-brown;
       }
+    }
+  }
+
+  &.validation {
+    .form-title {
+      text-align: left;
+      margin-left: .5em;
     }
   }
 

--- a/src/stylesheets/reusables/form.scss
+++ b/src/stylesheets/reusables/form.scss
@@ -11,6 +11,9 @@ form {
       display: block;
       margin: auto;
     }
+  }
+
+  &.log-in, &.validation {
     button.btn {
       display: block;
       margin: auto;
@@ -87,15 +90,30 @@ form {
     }
   }
 
-  .btn {
+  button.btn {
+    display: block;
     background: $blue;
     border-radius: .25em;
+    padding: 6px 12px;
     font-weight: bold;
     transition: background 1s, color 1s;
     margin: .5em;
+    min-height: 24px;
     &:hover {
       background: $gray-brown;
       color: $white;
     }
+    &:disabled {
+      pointer-events: none;
+    }
+    svg {
+      fill: $white;
+      float: right;
+      width: 1.5em;
+      height: 100%;
+      margin-left: 1em;
+      vertical-align: middle;
+    }
   }
+
 }


### PR DESCRIPTION
The relevant server code for this has already been merged.

<img width="892" alt="screen shot 2019-02-12 at 1 24 09 pm" src="https://user-images.githubusercontent.com/42178216/52658623-8c614580-2ec9-11e9-8860-865c6097140a.png">
<img width="891" alt="screen shot 2019-02-12 at 1 23 54 pm" src="https://user-images.githubusercontent.com/42178216/52658628-8ec39f80-2ec9-11e9-8f8e-2bc1121b54b5.png">
<img width="846" alt="screen shot 2019-02-12 at 1 23 32 pm" src="https://user-images.githubusercontent.com/42178216/52658637-9125f980-2ec9-11e9-8bc3-3adc58b11a09.png">
