### PR TITLE
Update names and copy to reflect new email functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.0.2
+#### Updated
+- Implemented functionality for manually validating an email address
+
 ### v1.0.1
 #### Added
 - Implemented form for re-sending validation emails

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -327,8 +327,8 @@ describe("actions", () => {
     });
   });
 
-  describe("email", () => {
-    it("sends an email", async () => {
+  describe("validate_email", () => {
+    it("validates an email address", async () => {
       const dispatch = stub();
       const formData = new (window as any).FormData();
       formData.append("uuid", "abc");
@@ -338,11 +338,11 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.email(formData)(dispatch);
+      await actions.validate_email(formData)(dispatch);
       expect(dispatch.callCount).to.equal(2);
 
-      expect(dispatch.args[0][0].type).to.equal("EMAIL_REQUEST");
-      expect(dispatch.args[1][0].type).to.equal("EMAIL_SUCCESS");
+      expect(dispatch.args[0][0].type).to.equal("VALIDATE_EMAIL_REQUEST");
+      expect(dispatch.args[1][0].type).to.equal("VALIDATE_EMAIL_SUCCESS");
 
       expect(fetchMock.callCount).to.equal(1);
       expect(fetchMock.args[0][0]).to.equal("/admin/libraries/email");

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -13,7 +13,7 @@ export default class ActionCreator extends BaseActionCreator {
   static readonly GET_ALL_LIBRARIES = "GET_ALL_LIBRARIES";
   static readonly GET_ONE_LIBRARY = "GET_ONE_LIBRARY";
 
-  static readonly EMAIL = "EMAIL";
+  static readonly VALIDATE_EMAIL = "VALIDATE_EMAIL";
   static readonly EDIT_STAGES = "EDIT_STAGES";
 
   static readonly LOG_IN = "LOG_IN";
@@ -148,9 +148,9 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<LibraryData>(ActionCreator.GET_ONE_LIBRARY, url).bind(this);
   }
 
-  email(data: FormData) {
+  validate_email(data: FormData) {
     let url = "/admin/libraries/email";
-    return this.postForm(ActionCreator.EMAIL, url, data).bind(this);
+    return this.postForm(ActionCreator.VALIDATE_EMAIL, url, data).bind(this);
   }
 
   editStages(data: FormData) {

--- a/src/components/EmailValidationForm.tsx
+++ b/src/components/EmailValidationForm.tsx
@@ -8,26 +8,26 @@ import { State } from "../reducers/index";
 import { LibraryData } from "../interfaces";
 import { CheckSoloIcon } from "@nypl/dgx-svg-icons";
 
-export interface EmailFormState {
+export interface EmailValidationFormState {
   sent: boolean;
 }
 
-export interface EmailFormOwnProps {
+export interface EmailValidationFormOwnProps {
   library: LibraryData;
   store: Store<State>;
 }
 
-export interface EmailFormDispatchProps {
-  email: (data: FormData) => Promise<void>;
+export interface EmailValidationFormDispatchProps {
+  validate_email: (data: FormData) => Promise<void>;
 }
 
-export interface EmailFormStateProps {
+export interface EmailValidationFormStateProps {
   error?: FetchErrorData;
 }
 
-export interface EmailFormProps extends EmailFormOwnProps, EmailFormDispatchProps, EmailFormStateProps {}
+export interface EmailValidationFormProps extends EmailValidationFormOwnProps, EmailValidationFormDispatchProps, EmailValidationFormStateProps {}
 
-export class EmailForm extends React.Component<EmailFormProps, EmailFormState> {
+export class EmailValidationForm extends React.Component<EmailValidationFormProps, EmailValidationFormState> {
 
   constructor(props) {
     super(props);
@@ -36,7 +36,7 @@ export class EmailForm extends React.Component<EmailFormProps, EmailFormState> {
   }
 
   async sendEmail(data: FormData): Promise<void> {
-    await this.props.email(data);
+    await this.props.validate_email(data);
     this.setState({ sent: !this.props.error });
   }
 
@@ -45,10 +45,10 @@ export class EmailForm extends React.Component<EmailFormProps, EmailFormState> {
     let hasEmail = !!this.props.library.urls_and_contact.contact_email;
     let alreadyValidated = this.props.library.urls_and_contact.validated !== "Not validated";
 
-    let buttonText = hasEmail ? "Send Validation Email" : "No email address configured";
+    let buttonText = hasEmail ? "Validate email address" : "No email address configured";
     let buttonContent = <span>{buttonText}{icon}</span>;
     let infoText = (alreadyValidated && !this.state.sent && !this.props.error) ? "Already validated" : null;
-    let successText = `Validation email successfully sent to ${this.props.library.urls_and_contact.contact_email}`;
+    let successText = `Successfully validated ${this.props.library.urls_and_contact.contact_email}`;
 
     return (
         <Form
@@ -67,22 +67,22 @@ export class EmailForm extends React.Component<EmailFormProps, EmailFormState> {
   }
 }
 
-function mapStateToProps(state: State, ownProps: EmailFormOwnProps) {
+function mapStateToProps(state: State, ownProps: EmailValidationFormOwnProps) {
   return {
-    error: state.email && (state.email.formError || state.email.fetchError)
+    error: state.validation && (state.validation.formError || state.validation.fetchError)
   };
 }
 
-function mapDispatchToProps(dispatch: Function, ownProps: EmailFormOwnProps) {
+function mapDispatchToProps(dispatch: Function, ownProps: EmailValidationFormOwnProps) {
   let actions = new ActionCreator(null);
   return {
-    email: (data: FormData) => dispatch(actions.email(data)),
+    validate_email: (data: FormData) => dispatch(actions.validate_email(data)),
   };
 }
 
-const ConnectedEmailForm = connect<EmailFormStateProps, EmailFormDispatchProps, EmailFormOwnProps>(
+const ConnectedEmailValidationForm = connect<EmailValidationFormStateProps, EmailValidationFormDispatchProps, EmailValidationFormOwnProps>(
   mapStateToProps,
   mapDispatchToProps
-)(EmailForm);
+)(EmailValidationForm);
 
-export default ConnectedEmailForm;
+export default ConnectedEmailValidationForm;

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -7,7 +7,7 @@ import { State } from "../reducers/index";
 import LibraryDetailItem from "./LibraryDetailItem";
 import LibraryStageItem from "./LibraryStageItem";
 import Form from "./reusables/Form";
-import EmailForm from "./EmailForm";
+import EmailValidationForm from "./EmailValidationForm";
 import Tabs from "./reusables/Tabs";
 
 export interface LibraryDetailPageDispatchProps {
@@ -103,7 +103,7 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
       <div>
         { this.renderStages() }
         <hr></hr>
-        <EmailForm store={this.props.store} library={library} />
+        <EmailValidationForm store={this.props.store} library={library} />
         <hr></hr>
         <div className="detail-content">
           <Tabs items={tabItems}/>

--- a/src/components/__tests__/EmailValidationForm-test.tsx
+++ b/src/components/__tests__/EmailValidationForm-test.tsx
@@ -3,12 +3,12 @@ import * as Sinon from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
 import buildStore from "../../store";
-import { EmailForm } from "../EmailForm";
+import { EmailValidationForm } from "../EmailValidationForm";
 
-describe("EmailForm", () => {
+describe("EmailValidationForm", () => {
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
   let store;
-  let email: Sinon.SinonSpy;
+  let validate_email: Sinon.SinonSpy;
 
   beforeEach(() => {
     let library = {
@@ -31,9 +31,9 @@ describe("EmailForm", () => {
       }
     };
     store = buildStore();
-    email = Sinon.stub();
+    validate_email = Sinon.stub();
     wrapper = Enzyme.mount(
-      <EmailForm store={store} library={library} email={email}/>
+      <EmailValidationForm store={store} library={library} validate_email={validate_email}/>
     );
   });
 
@@ -55,14 +55,14 @@ describe("EmailForm", () => {
 
   it("displays the correct button content", () => {
     let button = wrapper.find("button");
-    expect(button.text()).to.contain("Send Validation Email");
+    expect(button.text()).to.contain("Validate email address");
     expect(button.prop("disabled")).not.to.be.true;
 
     let library = wrapper.prop("library");
     let validated = Object.assign(library.urls_and_contact, { "validated": "validation time" });
     wrapper.setProps({ library: Object.assign(library, { urls_and_contact: validated })});
     button = wrapper.find("button");
-    expect(button.text()).to.contain("Send Validation Email");
+    expect(button.text()).to.contain("Validate email address");
     expect(button.prop("disabled")).not.to.be.true;
 
     let noEmail = Object.assign(library.urls_and_contact, { contact_email: null });
@@ -100,7 +100,7 @@ describe("EmailForm", () => {
     info = wrapper.find(".alert-info");
     expect(info.length).to.equal(0);
 
-    wrapper.setProps({ error: { response: "Failed to send email" } });
+    wrapper.setProps({ error: { response: "Failed to validate email address" } });
     info = wrapper.find(".alert-info");
     expect(info.length).to.equal(0);
   });
@@ -108,8 +108,8 @@ describe("EmailForm", () => {
   it("submits on click", async () => {
     expect(wrapper.state()["sent"]).to.be.false;
     wrapper.find("button").simulate("click");
-    expect(email.callCount).to.equal(1);
-    expect(email.args[0][0].get("uuid")).to.equal("UUID1");
+    expect(validate_email.callCount).to.equal(1);
+    expect(validate_email.args[0][0].get("uuid")).to.equal("UUID1");
 
     const pause = (): Promise<void> => {
       return new Promise<void>(resolve => setTimeout(resolve, 0));
@@ -142,18 +142,18 @@ describe("EmailForm", () => {
 
     successMessage = wrapper.find(".alert-success");
     expect(successMessage.length).to.equal(1);
-    expect(successMessage.text()).to.equal("Validation email successfully sent to email1");
+    expect(successMessage.text()).to.equal("Successfully validated email1");
   });
 
   it("displays an error message", () => {
     let errorMessage = wrapper.find(".alert-danger");
     expect(errorMessage.length).to.equal(0);
 
-    wrapper.setProps({ error: { response: "Failed to send email" } });
+    wrapper.setProps({ error: { response: "Failed to validate email address" } });
 
     errorMessage = wrapper.find(".alert-danger");
     expect(errorMessage.length).to.equal(1);
-    expect(errorMessage.text()).to.equal("Failed to send email");
+    expect(errorMessage.text()).to.equal("Failed to validate email address");
   });
 
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,6 @@ export interface AdminData {
   username: string;
 }
 
-export interface EmailData {
+export interface ValidationData {
   error?: FetchErrorData;
 }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -2,14 +2,14 @@ import { combineReducers } from "redux";
 import libraries from "./libraries";
 import library from "./library";
 import admin from "./admin";
-import email from "./email";
+import validation from "./validation";
 
 import { FetchEditState } from "./createFetchEditReducer";
 
 import {
   LibrariesData,
   LibraryData,
-  EmailData,
+  ValidationData,
   AdminData
 } from "../interfaces";
 
@@ -17,12 +17,12 @@ export interface State {
   libraries: FetchEditState<LibrariesData>;
   library: FetchEditState<LibraryData>;
   admin: FetchEditState<AdminData>;
-  email: FetchEditState<EmailData>;
+  validation: FetchEditState<ValidationData>;
 }
 
 export default combineReducers<State>({
   libraries,
   library,
   admin,
-  email
+  validation
 });

--- a/src/reducers/validation.ts
+++ b/src/reducers/validation.ts
@@ -1,9 +1,9 @@
-import { EmailData } from "../interfaces";
+import { ValidationData } from "../interfaces";
 import ActionCreator from "../actions";
 import createFetchEditReducer from "./createFetchEditReducer";
 import { RequestError } from "opds-web-client/lib/DataFetcher";
 
 
-export default createFetchEditReducer<EmailData>(
-  ActionCreator.EMAIL
+export default createFetchEditReducer<ValidationData>(
+  ActionCreator.VALIDATE_EMAIL
 );


### PR DESCRIPTION
I changed the email validation feature such that, instead of sending a validation email, it manually validates the email address.  The intended use case involves a situation in which we already know that the email address is valid, but the validation link has expired because the recipient didn't click on it in time; it makes more sense to manually validate the email address than to modify the server-side logic for determining which type of email to send, as it turns out we would need to do.  The actual functionality for this is in the server code (already merged); this branch is just updating some copy and variable names to reflect the changes.

https://jira.nypl.org/browse/SIMPLY-1573