### PR TITLE
Update library info after validating email, and change variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.0.3
+#### Updated
+- Made the validation timestamp automatically update as soon as a user validates an email address 
+
 ### v1.0.2
 #### Updated
 - Implemented functionality for manually validating an email address

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/__tests__/actions-test.ts
+++ b/src/__tests__/actions-test.ts
@@ -327,7 +327,7 @@ describe("actions", () => {
     });
   });
 
-  describe("validate_email", () => {
+  describe("validateEmail", () => {
     it("validates an email address", async () => {
       const dispatch = stub();
       const formData = new (window as any).FormData();
@@ -338,7 +338,7 @@ describe("actions", () => {
       }));
       fetch = fetchMock;
 
-      await actions.validate_email(formData)(dispatch);
+      await actions.validateEmail(formData)(dispatch);
       expect(dispatch.callCount).to.equal(2);
 
       expect(dispatch.args[0][0].type).to.equal("VALIDATE_EMAIL_REQUEST");

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -148,7 +148,7 @@ export default class ActionCreator extends BaseActionCreator {
     return this.fetchJSON<LibraryData>(ActionCreator.GET_ONE_LIBRARY, url).bind(this);
   }
 
-  validate_email(data: FormData) {
+  validateEmail(data: FormData) {
     let url = "/admin/libraries/email";
     return this.postForm(ActionCreator.VALIDATE_EMAIL, url, data).bind(this);
   }

--- a/src/components/EmailValidationForm.tsx
+++ b/src/components/EmailValidationForm.tsx
@@ -15,10 +15,11 @@ export interface EmailValidationFormState {
 export interface EmailValidationFormOwnProps {
   library: LibraryData;
   store: Store<State>;
+  fetchLibrary: (uuid: string) => LibraryData;
 }
 
 export interface EmailValidationFormDispatchProps {
-  validate_email: (data: FormData) => Promise<void>;
+  validateEmail: (data: FormData) => Promise<void>;
 }
 
 export interface EmailValidationFormStateProps {
@@ -36,7 +37,8 @@ export class EmailValidationForm extends React.Component<EmailValidationFormProp
   }
 
   async sendEmail(data: FormData): Promise<void> {
-    await this.props.validate_email(data);
+    await this.props.validateEmail(data);
+    await this.props.fetchLibrary(this.props.library.uuid);
     this.setState({ sent: !this.props.error });
   }
 
@@ -76,7 +78,7 @@ function mapStateToProps(state: State, ownProps: EmailValidationFormOwnProps) {
 function mapDispatchToProps(dispatch: Function, ownProps: EmailValidationFormOwnProps) {
   let actions = new ActionCreator(null);
   return {
-    validate_email: (data: FormData) => dispatch(actions.validate_email(data)),
+    validateEmail: (data: FormData) => dispatch(actions.validateEmail(data)),
   };
 }
 

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -103,7 +103,11 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
       <div>
         { this.renderStages() }
         <hr></hr>
-        <EmailValidationForm store={this.props.store} library={library} />
+        <EmailValidationForm
+          store={this.props.store}
+          library={library}
+          fetchLibrary={this.props.fetchLibrary}
+        />
         <hr></hr>
         <div className="detail-content">
           <Tabs items={tabItems}/>

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -87,7 +87,7 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
     if (!this.props.library) {
       return null;
     }
-    let library = this.props.fullLibrary || this.props.library;
+    let library = (this.props.fullLibrary && this.props.fullLibrary.uuid === this.props.library.uuid) ? this.props.fullLibrary : this.props.library;
     let tabItems = {};
 
     const categories = {

--- a/src/components/__tests__/EmailValidationForm-test.tsx
+++ b/src/components/__tests__/EmailValidationForm-test.tsx
@@ -8,7 +8,8 @@ import { EmailValidationForm } from "../EmailValidationForm";
 describe("EmailValidationForm", () => {
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
   let store;
-  let validate_email: Sinon.SinonSpy;
+  let validateEmail: Sinon.SinonStub;
+  let fetchLibrary: Sinon.SinonStub;
 
   beforeEach(() => {
     let library = {
@@ -31,9 +32,15 @@ describe("EmailValidationForm", () => {
       }
     };
     store = buildStore();
-    validate_email = Sinon.stub();
+    validateEmail = Sinon.stub();
+    fetchLibrary = Sinon.stub();
     wrapper = Enzyme.mount(
-      <EmailValidationForm store={store} library={library} validate_email={validate_email}/>
+      <EmailValidationForm
+        store={store}
+        library={library}
+        validateEmail={validateEmail}
+        fetchLibrary={fetchLibrary}
+      />
     );
   });
 
@@ -108,14 +115,16 @@ describe("EmailValidationForm", () => {
   it("submits on click", async () => {
     expect(wrapper.state()["sent"]).to.be.false;
     wrapper.find("button").simulate("click");
-    expect(validate_email.callCount).to.equal(1);
-    expect(validate_email.args[0][0].get("uuid")).to.equal("UUID1");
+    expect(validateEmail.callCount).to.equal(1);
+    expect(validateEmail.args[0][0].get("uuid")).to.equal("UUID1");
 
     const pause = (): Promise<void> => {
       return new Promise<void>(resolve => setTimeout(resolve, 0));
     };
     await pause();
 
+    expect(fetchLibrary.callCount).to.equal(1);
+    expect(fetchLibrary.args[0][0]).to.equal("UUID1");
     expect(wrapper.state()["sent"]).to.be.true;
   });
 


### PR DESCRIPTION
https://jira.nypl.org/browse/SIMPLY-1725

Use with https://github.com/NYPL-Simplified/library_registry/pull/102 to get rid of the weird flash when the info updates.

Added a call to `fetchLibrary` after email address is validated.

(Also, I changed the variable name `validate_email` to `validateEmail`, just because JS syntax.)

Update: discovered a bug whereby `fetchLibrary` was causing all of the `LibraryDetailPage` tab components to display the info for the library that gets fetched.  Fixed it by checking the uuid in `LibraryDetailPage.tsx`.