### PR TITLE
Add "Areas" tab in library detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.1.5
+#### Added
+- Created a new tab to display information about each library's focus area and service area.
+
 ### v1.1.4
 #### Updated
 - Utilized new built-in styling options for the Button component.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -99,9 +99,10 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
       "Contact & URLs": "urls_and_contact",
       "Areas": "areas"
     };
-    Object.entries(categories).filter(([k, v]) => library[v]).forEach(([k, v]) => {
+    Object.entries(categories).forEach(([k, v]) => {
+    // Object.entries(categories).filter(([k, v]) => library[v]).forEach(([k, v]) => {
       let category = library[v];
-      let categoryItems: any[] = Object.values(category);
+      let categoryItems: (string | string[])[] = Object.values(category);
       // If there are no meaningful items in this category--e.g. it's an Areas category in which
       // both values are empty arrays--then don't bother making a blank tab for it.
       let hasItems = categoryItems.some(x => x && x.length > 0);

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -46,10 +46,14 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
   }
 
   renderItems(category: {[key: string]: string}): JSX.Element {
+    // If the value is an array--e.g. of focus or service areas--format it as a semicolon-separated list.
+    let formatValue = (value: string | string[]) => {
+      return (Array.isArray(value) ? value.join("; ") : `${value}`);
+    };
 
     // Only create LibraryDetailItems for fields which actually have a value.
-    let fields = Object.keys(category).filter(label => category[label]).map(label =>
-      <LibraryDetailItem key={label} label={label} value={`${category[label]}`} />
+    let fields = Object.keys(category).filter(label => category[label] && category[label].length).map(label =>
+      <LibraryDetailItem key={label} label={label} value={formatValue(category[label])} />
     );
 
     return (
@@ -92,11 +96,16 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
 
     const categories = {
       "Basic Information": "basic_info",
-      "Contact & URLs": "urls_and_contact"
+      "Contact & URLs": "urls_and_contact",
+      "Areas": "areas"
     };
-
-    Object.keys(categories).forEach(tabName => {
-      tabItems[tabName] = this.renderItems(library[categories[tabName]]);
+    Object.entries(categories).filter(([k, v]) => library[v]).forEach(([k, v]) => {
+      let category = library[v];
+      let categoryItems: any[] = Object.values(category);
+      // If there are no meaningful items in this category--e.g. it's an Areas category in which
+      // both values are empty arrays--then don't bother making a blank tab for it.
+      let hasItems = categoryItems.some(x => x && x.length > 0);
+      hasItems && (tabItems[k] = this.renderItems(category));
     });
 
     return(

--- a/src/components/__tests__/EmailValidationForm-test.tsx
+++ b/src/components/__tests__/EmailValidationForm-test.tsx
@@ -3,6 +3,7 @@ import * as Sinon from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
 import buildStore from "../../store";
+import { testLibrary1 } from "./library-data";
 import { EmailValidationForm } from "../EmailValidationForm";
 
 describe("EmailValidationForm", () => {
@@ -12,25 +13,8 @@ describe("EmailValidationForm", () => {
   let fetchLibrary: Sinon.SinonStub;
 
   beforeEach(() => {
-    let library = {
-      uuid: "UUID1",
-      basic_info: {
-        "name": "Test Library 1",
-        "short_name": "lib1",
-        "description": undefined
-      },
-      urls_and_contact: {
-        "authentication_url": "auth1",
-        "contact_email": "email1",
-        "opds_url": "opds1",
-        "web_url": "web1",
-        "validated": "Not validated"
-      },
-      stages: {
-        "library_stage": "production",
-        "registry_stage": "testing"
-      }
-    };
+    let library = {...testLibrary1, ...{urls_and_contact: {...testLibrary1.urls_and_contact, ...{validated: "Not validated"}}}};
+
     store = buildStore();
     validateEmail = Sinon.stub();
     fetchLibrary = Sinon.stub();

--- a/src/components/__tests__/EmailValidationForm-test.tsx
+++ b/src/components/__tests__/EmailValidationForm-test.tsx
@@ -13,7 +13,7 @@ describe("EmailValidationForm", () => {
   let fetchLibrary: Sinon.SinonStub;
 
   beforeEach(() => {
-    const library = {...testLibrary1, ...{urls_and_contact: {...testLibrary1.urls_and_contact, ...{validated: "Not validated"}}}};
+    const library = {...testLibrary1, urls_and_contact: {...testLibrary1.urls_and_contact, validated: "Not validated"}};
 
     store = buildStore();
     validateEmail = Sinon.stub();

--- a/src/components/__tests__/EmailValidationForm-test.tsx
+++ b/src/components/__tests__/EmailValidationForm-test.tsx
@@ -3,7 +3,7 @@ import * as Sinon from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
 import buildStore from "../../store";
-import { testLibrary1, modify } from "./library-data";
+import { testLibrary1, modifyLibrary } from "./TestUtils";
 import { EmailValidationForm } from "../EmailValidationForm";
 
 describe("EmailValidationForm", () => {
@@ -13,7 +13,7 @@ describe("EmailValidationForm", () => {
   let fetchLibrary: Sinon.SinonStub;
 
   beforeEach(() => {
-    const library = modify(testLibrary1, {"validated": "Not validated"}, "urls_and_contact");
+    const library = modifyLibrary(testLibrary1, {"validated": "Not validated"}, "urls_and_contact");
     store = buildStore();
     validateEmail = Sinon.stub();
     fetchLibrary = Sinon.stub();
@@ -49,12 +49,12 @@ describe("EmailValidationForm", () => {
     expect(button.prop("disabled")).not.to.be.true;
 
     let library = wrapper.prop("library");
-    wrapper.setProps({ library: modify(library, {"validated": "validation time" })});
+    wrapper.setProps({ library: modifyLibrary(library, {"validated": "validation time" })});
     button = wrapper.find("button");
     expect(button.text()).to.contain("Validate email address");
     expect(button.prop("disabled")).not.to.be.true;
 
-    wrapper.setProps({ library: modify(library, {contact_email: null}) });
+    wrapper.setProps({ library: modifyLibrary(library, {contact_email: null}) });
     button = wrapper.find("button");
     expect(button.text()).to.equal("No email address configured");
     expect(button.prop("disabled")).to.be.true;
@@ -76,7 +76,7 @@ describe("EmailValidationForm", () => {
     expect(info.length).to.equal(0);
 
     let library = wrapper.prop("library");
-    wrapper.setProps({ library: modify(library, {"validated": "validation time" })});
+    wrapper.setProps({ library: modifyLibrary(library, {"validated": "validation time" })});
 
     info = wrapper.find(".alert-info");
     expect(info.length).to.equal(1);

--- a/src/components/__tests__/EmailValidationForm-test.tsx
+++ b/src/components/__tests__/EmailValidationForm-test.tsx
@@ -3,7 +3,7 @@ import * as Sinon from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
 import buildStore from "../../store";
-import { testLibrary1 } from "./library-data";
+import { testLibrary1, modify } from "./library-data";
 import { EmailValidationForm } from "../EmailValidationForm";
 
 describe("EmailValidationForm", () => {
@@ -13,8 +13,7 @@ describe("EmailValidationForm", () => {
   let fetchLibrary: Sinon.SinonStub;
 
   beforeEach(() => {
-    const library = {...testLibrary1, urls_and_contact: {...testLibrary1.urls_and_contact, validated: "Not validated"}};
-
+    const library = modify(testLibrary1, {"validated": "Not validated"}, "urls_and_contact");
     store = buildStore();
     validateEmail = Sinon.stub();
     fetchLibrary = Sinon.stub();
@@ -50,14 +49,12 @@ describe("EmailValidationForm", () => {
     expect(button.prop("disabled")).not.to.be.true;
 
     let library = wrapper.prop("library");
-    let validated = Object.assign(library.urls_and_contact, { "validated": "validation time" });
-    wrapper.setProps({ library: Object.assign(library, { urls_and_contact: validated })});
+    wrapper.setProps({ library: modify(library, {"validated": "validation time" })});
     button = wrapper.find("button");
     expect(button.text()).to.contain("Validate email address");
     expect(button.prop("disabled")).not.to.be.true;
 
-    let noEmail = Object.assign(library.urls_and_contact, { contact_email: null });
-    wrapper.setProps({ library: Object.assign(library, { urls_and_contact: noEmail })});
+    wrapper.setProps({ library: modify(library, {contact_email: null}) });
     button = wrapper.find("button");
     expect(button.text()).to.equal("No email address configured");
     expect(button.prop("disabled")).to.be.true;
@@ -79,8 +76,7 @@ describe("EmailValidationForm", () => {
     expect(info.length).to.equal(0);
 
     let library = wrapper.prop("library");
-    let validated = Object.assign(library.urls_and_contact, { "validated": "validation time" });
-    wrapper.setProps({ library: Object.assign(library, { urls_and_contact: validated })});
+    wrapper.setProps({ library: modify(library, {"validated": "validation time" })});
 
     info = wrapper.find(".alert-info");
     expect(info.length).to.equal(1);

--- a/src/components/__tests__/EmailValidationForm-test.tsx
+++ b/src/components/__tests__/EmailValidationForm-test.tsx
@@ -13,7 +13,7 @@ describe("EmailValidationForm", () => {
   let fetchLibrary: Sinon.SinonStub;
 
   beforeEach(() => {
-    let library = {...testLibrary1, ...{urls_and_contact: {...testLibrary1.urls_and_contact, ...{validated: "Not validated"}}}};
+    const library = {...testLibrary1, ...{urls_and_contact: {...testLibrary1.urls_and_contact, ...{validated: "Not validated"}}}};
 
     store = buildStore();
     validateEmail = Sinon.stub();

--- a/src/components/__tests__/LibrariesList-test.tsx
+++ b/src/components/__tests__/LibrariesList-test.tsx
@@ -9,7 +9,7 @@ import LibrariesList from "../LibrariesList";
 import LibrariesListItem from "../LibrariesListItem";
 
 describe("LibrariesList", () => {
-  let libraries = [testLibrary1, testLibrary2];
+  const libraries = [testLibrary1, testLibrary2];
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
   let store;
   describe("rendering", () => {

--- a/src/components/__tests__/LibrariesList-test.tsx
+++ b/src/components/__tests__/LibrariesList-test.tsx
@@ -3,48 +3,13 @@ import * as Sinon from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
 import buildStore from "../../store";
+import { testLibrary1, testLibrary2 } from "./library-data";
 
 import LibrariesList from "../LibrariesList";
 import LibrariesListItem from "../LibrariesListItem";
 
 describe("LibrariesList", () => {
-  let libraries = [
-       {
-        uuid: "UUID1",
-        basic_info: {
-          "name": "Test Library 1",
-          "short_name": "lib1",
-        },
-        urls_and_contact: {
-          "authentication_url": "auth1",
-          "contact_email": "email1",
-          "opds_url": "opds1",
-          "web_url": "web1"
-        },
-        stages: {
-          "library_stage": "production",
-          "registry_stage": "testing"
-        }
-      },
-      {
-        uuid: "UUID2",
-        basic_info: {
-          "name": "Test Library 2",
-          "short_name": "lib2",
-
-        },
-        urls_and_contact: {
-          "authentication_url": "auth2",
-          "contact_email": "email2",
-          "opds_url": "opds2",
-          "web_url": "web2"        },
-        stages: {
-          "library_stage": "testing",
-          "registry_stage": "cancelled"
-        }
-      }
-    ];
-
+  let libraries = [testLibrary1, testLibrary2];
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
   let store;
   describe("rendering", () => {

--- a/src/components/__tests__/LibrariesList-test.tsx
+++ b/src/components/__tests__/LibrariesList-test.tsx
@@ -3,7 +3,7 @@ import * as Sinon from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
 import buildStore from "../../store";
-import { testLibrary1, testLibrary2, modify } from "./library-data";
+import { testLibrary1, testLibrary2, modifyLibrary } from "./TestUtils";
 
 import LibrariesList from "../LibrariesList";
 import LibrariesListItem from "../LibrariesListItem";
@@ -37,7 +37,7 @@ describe("LibrariesList", () => {
     });
 
     it("should update if the libraries prop changes", () => {
-      let newLib1 = modify(testLibrary1, { name: "New Library!", short_name: "new" });
+      let newLib1 = modifyLibrary(testLibrary1, { name: "New Library!", short_name: "new" });
       wrapper.setProps({ libraries: [newLib1, libraries[1]] });
 
       let libraryPanels = wrapper.find(".list .panel");

--- a/src/components/__tests__/LibrariesList-test.tsx
+++ b/src/components/__tests__/LibrariesList-test.tsx
@@ -3,7 +3,7 @@ import * as Sinon from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
 import buildStore from "../../store";
-import { testLibrary1, testLibrary2 } from "./library-data";
+import { testLibrary1, testLibrary2, modify } from "./library-data";
 
 import LibrariesList from "../LibrariesList";
 import LibrariesListItem from "../LibrariesListItem";
@@ -37,9 +37,8 @@ describe("LibrariesList", () => {
     });
 
     it("should update if the libraries prop changes", () => {
-      let newLib1 = Object.assign({}, libraries[0], { basic_info: { name: "New Library!", short_name: "new" } });
-      let newProps = [newLib1, libraries[1]];
-      wrapper.setProps({ libraries: newProps });
+      let newLib1 = modify(testLibrary1, { name: "New Library!", short_name: "new" });
+      wrapper.setProps({ libraries: [newLib1, libraries[1]] });
 
       let libraryPanels = wrapper.find(".list .panel");
       expect(libraryPanels.length).to.equal(2);

--- a/src/components/__tests__/LibrariesListItem-test.tsx
+++ b/src/components/__tests__/LibrariesListItem-test.tsx
@@ -9,7 +9,7 @@ import LibrariesListItem from "../LibrariesListItem";
 import { Panel } from "library-simplified-reusable-components";
 
 describe("LibrariesListItem", () => {
-  let library = testLibrary1;
+  const library = testLibrary1;
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
   let store;
   describe("rendering", () => {

--- a/src/components/__tests__/LibrariesListItem-test.tsx
+++ b/src/components/__tests__/LibrariesListItem-test.tsx
@@ -3,29 +3,13 @@ import { expect } from "chai";
 import * as React from "react";
 import * as Enzyme from "enzyme";
 import buildStore from "../../store";
+import { testLibrary1 } from "./library-data";
 
 import LibrariesListItem from "../LibrariesListItem";
 import { Panel } from "library-simplified-reusable-components";
 
 describe("LibrariesListItem", () => {
-  let library = {
-    uuid: "UUID1",
-    basic_info: {
-      "name": "Test Library",
-      "short_name": "test_lib",
-
-    },
-    urls_and_contact: {
-      "authentication_url": "test_auth",
-      "contact_email": "test_email",
-      "opds_url": "test_opds",
-      "web_url": "test_web"
-    },
-    stages: {
-      "library_stage": "production",
-      "registry_stage": "testing"
-    }
-  };
+  let library = testLibrary1;
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
   let store;
   describe("rendering", () => {
@@ -46,7 +30,7 @@ describe("LibrariesListItem", () => {
       expect(header.length).to.equal(1);
       let title = header.find(".panel-title");
       expect(title.length).to.equal(1);
-      expect(title.text()).to.contain("Test Library (test_lib)");
+      expect(title.text()).to.contain("Test Library 1 (lib1)");
     });
     it("should display an icon in the header", () => {
       let header = wrapper.find(".panel-heading");

--- a/src/components/__tests__/LibrariesListItem-test.tsx
+++ b/src/components/__tests__/LibrariesListItem-test.tsx
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import * as React from "react";
 import * as Enzyme from "enzyme";
 import buildStore from "../../store";
-import { testLibrary1 } from "./library-data";
+import { testLibrary1 } from "./TestUtils";
 
 import LibrariesListItem from "../LibrariesListItem";
 import { Panel } from "library-simplified-reusable-components";

--- a/src/components/__tests__/LibrariesPage-test.tsx
+++ b/src/components/__tests__/LibrariesPage-test.tsx
@@ -4,7 +4,7 @@ import * as Enzyme from "enzyme";
 import * as React from "react";
 import buildStore from "../../store";
 
-import { testLibrary1, testLibrary2, modify } from "./library-data";
+import { testLibrary1, testLibrary2, modifyLibrary } from "./TestUtils";
 import { LibrariesPage } from "../LibrariesPage";
 import LibrariesList from "../LibrariesList";
 import Toggle from "../reusables/Toggle";
@@ -13,8 +13,8 @@ import SearchForm from "../SearchForm";
 describe("LibrariesPage", () => {
 
     const libraries = [
-      modify(testLibrary1, {registry_stage: "production"}),
-      modify(testLibrary2, {registry_stage: "production"})
+      modifyLibrary(testLibrary1, {registry_stage: "production"}),
+      modifyLibrary(testLibrary2, {registry_stage: "production"})
     ];
 
     let qaLib = {

--- a/src/components/__tests__/LibrariesPage-test.tsx
+++ b/src/components/__tests__/LibrariesPage-test.tsx
@@ -11,7 +11,7 @@ import SearchForm from "../SearchForm";
 
 describe("LibrariesPage", () => {
 
-    let libraries = [testLibrary1, testLibrary2];
+    const libraries = [testLibrary1, testLibrary2];
     let fetchData = Sinon.stub();
     let search = Sinon.stub().returns(libraries[1]);
     let wrapper: Enzyme.CommonWrapper<{}, {}, {}>;

--- a/src/components/__tests__/LibrariesPage-test.tsx
+++ b/src/components/__tests__/LibrariesPage-test.tsx
@@ -4,48 +4,14 @@ import * as Enzyme from "enzyme";
 import * as React from "react";
 import buildStore from "../../store";
 
+import { testLibrary1, testLibrary2 } from "./library-data";
 import { LibrariesPage } from "../LibrariesPage";
 import LibrariesList from "../LibrariesList";
 import SearchForm from "../SearchForm";
 
 describe("LibrariesPage", () => {
 
-  let libraries = [
-       {
-        uuid: "UUID1",
-        basic_info: {
-          "name": "Test Library 1",
-          "short_name": "lib1",
-        },
-        urls_and_contact: {
-          "authentication_url": "auth1",
-          "contact_email": "email1",
-          "opds_url": "opds1",
-          "web_url": "web1"
-        },
-        stages: {
-          "library_stage": "production",
-          "registry_stage": "testing"
-        }
-      },
-      {
-        uuid: "UUID2",
-        basic_info: {
-          "name": "Test Library 2",
-          "short_name": "lib2",
-        },
-        urls_and_contact: {
-          "authentication_url": "auth2",
-          "contact_email": "email2",
-          "opds_url": "opds2",
-          "web_url": "web2"
-        },
-        stages: {
-          "library_stage": "testing",
-          "registry_stage": "cancelled"
-        }
-      }
-    ];
+    let libraries = [testLibrary1, testLibrary2];
     let fetchData = Sinon.stub();
     let search = Sinon.stub().returns(libraries[1]);
     let wrapper: Enzyme.CommonWrapper<{}, {}, {}>;

--- a/src/components/__tests__/LibraryDetailPage-test.tsx
+++ b/src/components/__tests__/LibraryDetailPage-test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import buildStore from "../../store";
 import { LibraryDetailPage } from "../LibraryDetailPage";
 import LibraryDetailItem from "../LibraryDetailItem";
-import { testLibrary1, modify } from "./library-data";
+import { testLibrary1, modifyLibrary } from "./TestUtils";
 
 describe("LibraryDetailPage", () => {
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
@@ -102,7 +102,7 @@ describe("LibraryDetailPage", () => {
     let tabs = wrapper.find(".tab-nav");
     expect(tabs.length).to.equal(3);
     expect(wrapper.find(".tab-navs").text()).to.contain("Areas");
-    let libraryWithoutAreas = modify(testLibrary1, {focus: [], service: []});
+    let libraryWithoutAreas = modifyLibrary(testLibrary1, {focus: [], service: []});
     wrapper.setProps({library: libraryWithoutAreas});
     tabs = wrapper.find(".tab-nav");
     expect(tabs.length).to.equal(2);
@@ -143,7 +143,7 @@ describe("LibraryDetailPage", () => {
     let form = wrapper.find("form").at(0);
     let button = form.find("button");
     button.simulate("click");
-    let fullLibrary = modify(testLibrary1, { library_stage: "cancelled", registry_stage: "production" });
+    let fullLibrary = modifyLibrary(testLibrary1, { library_stage: "cancelled", registry_stage: "production" });
     wrapper.setProps({ fullLibrary });
 
     expect(editStages.callCount).to.equal(1);
@@ -176,7 +176,7 @@ describe("LibraryDetailPage", () => {
 
     let saveButton = editForm.find("button");
     saveButton.simulate("click");
-    let fullLibrary = modify(library, { library_stage: "testing", registry_stage: "cancelled" });
+    let fullLibrary = modifyLibrary(library, { library_stage: "testing", registry_stage: "cancelled" });
     wrapper.setProps({ fullLibrary });
 
     const pause = (): Promise<void> => {

--- a/src/components/__tests__/LibraryDetailPage-test.tsx
+++ b/src/components/__tests__/LibraryDetailPage-test.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import buildStore from "../../store";
 import { LibraryDetailPage } from "../LibraryDetailPage";
 import LibraryDetailItem from "../LibraryDetailItem";
-import { testLibrary1 } from "./library-data";
+import { testLibrary1, modify } from "./library-data";
 
 describe("LibraryDetailPage", () => {
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
@@ -102,7 +102,7 @@ describe("LibraryDetailPage", () => {
     let tabs = wrapper.find(".tab-nav");
     expect(tabs.length).to.equal(3);
     expect(wrapper.find(".tab-navs").text()).to.contain("Areas");
-    let libraryWithoutAreas = {...library, areas: {focus: [], service: []}};
+    let libraryWithoutAreas = modify(testLibrary1, {focus: [], service: []});
     wrapper.setProps({library: libraryWithoutAreas});
     tabs = wrapper.find(".tab-nav");
     expect(tabs.length).to.equal(2);
@@ -143,9 +143,7 @@ describe("LibraryDetailPage", () => {
     let form = wrapper.find("form").at(0);
     let button = form.find("button");
     button.simulate("click");
-
-    let newStages = { stages: { library_stage: "cancelled", registry_stage: "production" } };
-    let fullLibrary = Object.assign({}, (wrapper.props() as any)["library"], newStages);
+    let fullLibrary = modify(testLibrary1, { library_stage: "cancelled", registry_stage: "production" });
     wrapper.setProps({ fullLibrary });
 
     expect(editStages.callCount).to.equal(1);
@@ -178,8 +176,7 @@ describe("LibraryDetailPage", () => {
 
     let saveButton = editForm.find("button");
     saveButton.simulate("click");
-    let newStages = { stages: { library_stage: "testing", registry_stage: "cancelled" } };
-    let fullLibrary = Object.assign({}, (wrapper.props() as any)["library"], newStages);
+    let fullLibrary = modify(library, { library_stage: "testing", registry_stage: "cancelled" });
     wrapper.setProps({ fullLibrary });
 
     const pause = (): Promise<void> => {

--- a/src/components/__tests__/LibraryDetailPage-test.tsx
+++ b/src/components/__tests__/LibraryDetailPage-test.tsx
@@ -102,7 +102,7 @@ describe("LibraryDetailPage", () => {
     let tabs = wrapper.find(".tab-nav");
     expect(tabs.length).to.equal(3);
     expect(wrapper.find(".tab-navs").text()).to.contain("Areas");
-    let libraryWithoutAreas = {...library, ...{areas: {focus: [], service: []}}};
+    let libraryWithoutAreas = {...library, areas: {focus: [], service: []}};
     wrapper.setProps({library: libraryWithoutAreas});
     tabs = wrapper.find(".tab-nav");
     expect(tabs.length).to.equal(2);

--- a/src/components/__tests__/LibraryDetailPage-test.tsx
+++ b/src/components/__tests__/LibraryDetailPage-test.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import buildStore from "../../store";
 import { LibraryDetailPage } from "../LibraryDetailPage";
 import LibraryDetailItem from "../LibraryDetailItem";
+import { testLibrary1 } from "./library-data";
 
 describe("LibraryDetailPage", () => {
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
@@ -12,25 +13,7 @@ describe("LibraryDetailPage", () => {
   let uuid = "123";
   let store;
 
-  let library = {
-    uuid: "UUID1",
-    basic_info: {
-      "name": "Test Library 1",
-      "short_name": "lib1",
-      "description": undefined
-    },
-    urls_and_contact: {
-      "authentication_url": "auth1",
-      "contact_email": "email1",
-      "opds_url": "opds1",
-      "web_url": "web1"
-    },
-    stages: {
-      "library_stage": "production",
-      "registry_stage": "testing"
-    }
-  };
-
+  let library = testLibrary1;
   let updateColor: Sinon.SinonStub;
   let editStages: Sinon.SinonStub;
   let fetchLibrary: Sinon.SinonStub;
@@ -56,8 +39,8 @@ describe("LibraryDetailPage", () => {
     let spyRenderItems = Sinon.spy(wrapper.instance(), "renderItems");
     wrapper.instance().render();
 
-    expect(spyRenderItems.callCount).to.equal(2);
-    let [basicInfoCall, urlsContactCall] = [spyRenderItems.firstCall, spyRenderItems.secondCall];
+    expect(spyRenderItems.callCount).to.equal(3);
+    let [basicInfoCall, urlsContactCall, areasCall] = [spyRenderItems.firstCall, spyRenderItems.secondCall, spyRenderItems.thirdCall];
 
     expect(basicInfoCall.args[0]).to.equal(library.basic_info);
     expect(basicInfoCall.returnValue.type).to.equal("ul");
@@ -81,12 +64,19 @@ describe("LibraryDetailPage", () => {
     expect(web_url.props.label).to.equal("web_url");
     expect(web_url.props.value).to.equal("web1");
 
+    expect(areasCall.args[0]).to.equal(library.areas);
+    expect(areasCall.returnValue.type).to.equal("ul");
+    expect(areasCall.returnValue.props.children.length).to.equal(1);
+    let [focus] = areasCall.returnValue.props.children;
+    expect(focus.props.label).to.equal("focus");
+    expect(focus.props.value).to.equal(library.areas.focus.join("; "));
+
     spyRenderItems.restore();
   });
 
   it("should show the library information", () => {
     let list = wrapper.find(".list-group");
-    expect(list.length).to.equal(2);
+    expect(list.length).to.equal(3);
 
     let basicInfoItems = list.at(0).find("li");
     expect(basicInfoItems.length).to.equal(2);
@@ -106,6 +96,17 @@ describe("LibraryDetailPage", () => {
   it("should not display blank values", () => {
     let infoLabels = wrapper.find(".list-group-item .control-label").map((label: Enzyme.CommonWrapper<any, any, {}>) => label.text());
     expect(infoLabels.indexOf("description")).to.equal(-1);
+  });
+
+  it("should not display empty tabs", () => {
+    let tabs = wrapper.find(".tab-nav");
+    expect(tabs.length).to.equal(3);
+    expect(wrapper.find(".tab-navs").text()).to.contain("Areas");
+    let libraryWithoutAreas = {...library, ...{areas: null}};
+    wrapper.setProps({library: libraryWithoutAreas});
+    tabs = wrapper.find(".tab-nav");
+    expect(tabs.length).to.equal(2);
+    expect(wrapper.find(".tab-navs").text()).not.to.contain("Areas");
   });
 
   it("should display the edit form", () => {

--- a/src/components/__tests__/LibraryDetailPage-test.tsx
+++ b/src/components/__tests__/LibraryDetailPage-test.tsx
@@ -13,7 +13,7 @@ describe("LibraryDetailPage", () => {
   let uuid = "123";
   let store;
 
-  let library = testLibrary1;
+  const library = testLibrary1;
   let updateColor: Sinon.SinonStub;
   let editStages: Sinon.SinonStub;
   let fetchLibrary: Sinon.SinonStub;
@@ -102,7 +102,7 @@ describe("LibraryDetailPage", () => {
     let tabs = wrapper.find(".tab-nav");
     expect(tabs.length).to.equal(3);
     expect(wrapper.find(".tab-navs").text()).to.contain("Areas");
-    let libraryWithoutAreas = {...library, ...{areas: null}};
+    let libraryWithoutAreas = {...library, ...{areas: {focus: [], service: []}}};
     wrapper.setProps({library: libraryWithoutAreas});
     tabs = wrapper.find(".tab-nav");
     expect(tabs.length).to.equal(2);

--- a/src/components/__tests__/TestUtils.ts
+++ b/src/components/__tests__/TestUtils.ts
@@ -58,13 +58,13 @@ It's only necessary if we're adding a new key.
 */
 export const modifyLibrary = (baseLibrary: LibraryData, newData: {[key: string]: string | string[]}, category?: string): LibraryData => {
   let updatedLibrary = {...baseLibrary};
+  let allCategories = Object.keys(baseLibrary);
 
   Object.entries(newData).forEach((pair) => {
     let categoryToUpdate = category || null;
     let newValue = {};
     let [key, value] = pair;
     if (!categoryToUpdate) {
-      let allCategories = Object.keys(baseLibrary);
       categoryToUpdate = allCategories.find((cat) => Object.keys(baseLibrary[cat]).includes(key));
     }
     newValue[key] = value;

--- a/src/components/__tests__/TestUtils.ts
+++ b/src/components/__tests__/TestUtils.ts
@@ -1,3 +1,6 @@
+import { expect } from "chai";
+import * as Enzyme from "enzyme";
+
 import { LibraryData } from "../../interfaces";
 
 export const testLibrary1: LibraryData = {
@@ -45,29 +48,72 @@ export const testLibrary2: LibraryData = {
   }
 };
 
+/**
+* modifyLibrary()
+* @param {LibraryData} baseLibrary - the library to be modified
+* @param {{[key: string]: string | string[]}} newData - key-value pairs with which to update the library
+* @param {string} [category] - the category that the new values should go into.  This isn't necessary if we're
+modifying the value of a key that already exists in the library; modifyLibrary will figure it out.
+It's only necessary if we're adding a new key.
+*/
 export const modifyLibrary = (baseLibrary: LibraryData, newData: {[key: string]: string | string[]}, category?: string): LibraryData => {
-  /**
-   * modifyLibrary()
-   * @param {LibraryData} baseLibrary - the library to be modified
-   * @param {{[key: string]: string | string[]}} newData - key-value pairs with which to update the library
-   * @param {string} [category] - the category that the new values should go into.  This isn't necessary if we're
-     modifying the value of a key that already exists in the library; modifyLibrary will figure it out.
-     It's only necessary if we're adding a new key.
-  */
-
   let categories = Object.keys(baseLibrary);
-  let newValue = {};
   let updatedLibrary = {...baseLibrary};
 
   Object.entries(newData).forEach((pair) => {
+    let categoryToUpdate = category || null;
+    let newValue = {};
     let [key, value] = pair;
-    if (!category) {
+    if (!categoryToUpdate) {
       let allCategories = Object.keys(baseLibrary);
-      category = allCategories.find((cat) => Object.keys(baseLibrary[cat]).includes(key));
+      categoryToUpdate = allCategories.find((cat) => Object.keys(baseLibrary[cat]).includes(key));
     }
     newValue[key] = value;
-    let updatedCategory = { ...baseLibrary[category], ...newValue };
-    updatedLibrary[category] = updatedCategory;
+    let updatedCategory = { ...(updatedLibrary[categoryToUpdate] || baseLibrary[categoryToUpdate]), ...newValue };
+    updatedLibrary[categoryToUpdate] = updatedCategory;
   });
   return updatedLibrary;
 };
+
+describe("TestUtils", () => {
+  it("updates a library with one new value", () => {
+    let baseLibrary = testLibrary1;
+    expect(baseLibrary.stages.registry_stage).to.equal("testing");
+    let updatedLibrary = modifyLibrary(baseLibrary, {registry_stage: "production"});
+    expect(updatedLibrary.stages.registry_stage).to.equal("production");
+  });
+
+  it("updates a library with multiple new values from different categories", () => {
+    let baseLibrary = testLibrary1;
+    expect(baseLibrary.basic_info.name).to.equal("Test Library 1");
+    expect(baseLibrary.urls_and_contact.web_url).to.equal("web1");
+    expect(baseLibrary.areas.service).to.eql([]);
+    let updatedLibrary = modifyLibrary(baseLibrary, {
+      name: "New Name",
+      web_url: "new_url",
+      service: ["10069 (NY)"]
+    });
+    expect(updatedLibrary.basic_info.name).to.equal("New Name");
+    expect(updatedLibrary.urls_and_contact.web_url).to.equal("new_url");
+    expect(updatedLibrary.areas.service).to.eql(["10069 (NY)"]);
+  });
+
+  it("updates a library with multiple new values within the same category", () => {
+    let baseLibrary = testLibrary1;
+    expect(baseLibrary.basic_info.name).to.equal("Test Library 1");
+    expect(baseLibrary.basic_info.short_name).to.equal("lib1");
+    let updatedLibrary = modifyLibrary(baseLibrary, {
+      name: "New Name",
+      short_name: "New Short Name"
+    });
+    expect(updatedLibrary.basic_info.name).to.equal("New Name");
+    expect(updatedLibrary.basic_info.short_name).to.equal("New Short Name");
+  });
+
+  it("takes an optional category argument", () => {
+    let baseLibrary = testLibrary1;
+    expect(baseLibrary.urls_and_contact.validated).to.be.undefined;
+    let updatedLibrary = modifyLibrary(baseLibrary, {validated: "VALIDATED!"}, "urls_and_contact");
+    expect(updatedLibrary.urls_and_contact.validated).to.equal("VALIDATED!");
+  });
+});

--- a/src/components/__tests__/TestUtils.ts
+++ b/src/components/__tests__/TestUtils.ts
@@ -57,7 +57,6 @@ modifying the value of a key that already exists in the library; modifyLibrary w
 It's only necessary if we're adding a new key.
 */
 export const modifyLibrary = (baseLibrary: LibraryData, newData: {[key: string]: string | string[]}, category?: string): LibraryData => {
-  let categories = Object.keys(baseLibrary);
   let updatedLibrary = {...baseLibrary};
 
   Object.entries(newData).forEach((pair) => {
@@ -69,7 +68,7 @@ export const modifyLibrary = (baseLibrary: LibraryData, newData: {[key: string]:
       categoryToUpdate = allCategories.find((cat) => Object.keys(baseLibrary[cat]).includes(key));
     }
     newValue[key] = value;
-    let updatedCategory = { ...(updatedLibrary[categoryToUpdate] || baseLibrary[categoryToUpdate]), ...newValue };
+    let updatedCategory = { ...updatedLibrary[categoryToUpdate], ...newValue };
     updatedLibrary[categoryToUpdate] = updatedCategory;
   });
   return updatedLibrary;

--- a/src/components/__tests__/TestUtils.ts
+++ b/src/components/__tests__/TestUtils.ts
@@ -46,9 +46,15 @@ export const testLibrary2: LibraryData = {
 };
 
 export const modifyLibrary = (baseLibrary: LibraryData, newData: {[key: string]: string | string[]}, category?: string): LibraryData => {
-  // A helper function so that tests can easily modifyLibrary a library's data or create a new library
-  // based off of an existing one.  The category variable only needs to be passed if the modification
-  // entails adding a new key.
+  /**
+   * modifyLibrary()
+   * @param {LibraryData} baseLibrary - the library to be modified
+   * @param {{[key: string]: string | string[]}} newData - key-value pairs with which to update the library
+   * @param {string} [category] - the category that the new values should go into.  This isn't necessary if we're
+     modifying the value of a key that already exists in the library; modifyLibrary will figure it out.
+     It's only necessary if we're adding a new key.
+  */
+
   let categories = Object.keys(baseLibrary);
   let newValue = {};
   let updatedLibrary = {...baseLibrary};

--- a/src/components/__tests__/TestUtils.ts
+++ b/src/components/__tests__/TestUtils.ts
@@ -45,8 +45,8 @@ export const testLibrary2: LibraryData = {
   }
 };
 
-export const modify = (baseLibrary: LibraryData, newData: {[key: string]: string | string[]}, category?: string): LibraryData => {
-  // A helper function so that tests can easily modify a library's data or create a new library
+export const modifyLibrary = (baseLibrary: LibraryData, newData: {[key: string]: string | string[]}, category?: string): LibraryData => {
+  // A helper function so that tests can easily modifyLibrary a library's data or create a new library
   // based off of an existing one.  The category variable only needs to be passed if the modification
   // entails adding a new key.
   let categories = Object.keys(baseLibrary);

--- a/src/components/__tests__/library-data.ts
+++ b/src/components/__tests__/library-data.ts
@@ -1,0 +1,43 @@
+export const testLibrary1 = {
+  uuid: "UUID1",
+  basic_info: {
+    "name": "Test Library 1",
+    "short_name": "lib1",
+    "description": undefined
+  },
+  urls_and_contact: {
+    "authentication_url": "auth1",
+    "contact_email": "email1",
+    "opds_url": "opds1",
+    "web_url": "web1"
+  },
+  stages: {
+    "library_stage": "production",
+    "registry_stage": "testing"
+  },
+  areas: {
+    "focus": ["10025 (NY)", "Stratford (ON)", "33154 (FL)"],
+    "service": []
+  }
+};
+
+export const testLibrary2 = {
+  uuid: "UUID2",
+  basic_info: {
+    "name": "Test Library 2",
+    "short_name": "lib2",
+  },
+  urls_and_contact: {
+    "authentication_url": "auth2",
+    "contact_email": "email2",
+    "opds_url": "opds2",
+    "web_url": "web2"        },
+  stages: {
+    "library_stage": "testing",
+    "registry_stage": "cancelled"
+  },
+  areas: {
+    "focus": [],
+    "service": []
+  }
+};

--- a/src/components/__tests__/library-data.ts
+++ b/src/components/__tests__/library-data.ts
@@ -31,7 +31,8 @@ export const testLibrary2 = {
     "authentication_url": "auth2",
     "contact_email": "email2",
     "opds_url": "opds2",
-    "web_url": "web2"        },
+    "web_url": "web2"
+  },
   stages: {
     "library_stage": "testing",
     "registry_stage": "cancelled"

--- a/src/components/__tests__/library-data.ts
+++ b/src/components/__tests__/library-data.ts
@@ -1,4 +1,6 @@
-export const testLibrary1 = {
+import { LibraryData } from "../../interfaces";
+
+export const testLibrary1: LibraryData = {
   uuid: "UUID1",
   basic_info: {
     "name": "Test Library 1",
@@ -21,7 +23,7 @@ export const testLibrary1 = {
   }
 };
 
-export const testLibrary2 = {
+export const testLibrary2: LibraryData = {
   uuid: "UUID2",
   basic_info: {
     "name": "Test Library 2",
@@ -41,4 +43,25 @@ export const testLibrary2 = {
     "focus": [],
     "service": []
   }
+};
+
+export const modify = (baseLibrary: LibraryData, newData: {[key: string]: string | string[]}, category?: string): LibraryData => {
+  // A helper function so that tests can easily modify a library's data or create a new library
+  // based off of an existing one.  The category variable only needs to be passed if the modification
+  // entails adding a new key.
+  let categories = Object.keys(baseLibrary);
+  let newValue = {};
+  let updatedLibrary = {...baseLibrary};
+
+  Object.entries(newData).forEach((pair) => {
+    let [key, value] = pair;
+    if (!category) {
+      let allCategories = Object.keys(baseLibrary);
+      category = allCategories.find((cat) => Object.keys(baseLibrary[cat]).includes(key));
+    }
+    newValue[key] = value;
+    let updatedCategory = { ...baseLibrary[category], ...newValue };
+    updatedLibrary[category] = updatedCategory;
+  });
+  return updatedLibrary;
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,12 +10,16 @@ export interface LibraryData {
     short_name: string,
     timestamp?: string,
   };
-  urls_and_contact?: {
+  urls_and_contact: {
     authentication_url: string,
     contact_email: string,
     opds_url: string,
     web_url: string,
     validated?: string
+  };
+  areas: {
+    focus?: string[],
+    service?: string[]
   };
   stages: {
     library_stage: string,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,8 +18,8 @@ export interface LibraryData {
     validated?: string
   };
   areas: {
-    focus?: string[],
-    service?: string[]
+    focus: string[],
+    service: string[]
   };
   stages: {
     library_stage: string,


### PR DESCRIPTION
<img width="945" alt="Screen Shot 2019-05-31 at 4 29 20 PM" src="https://user-images.githubusercontent.com/42178216/58733032-53d67080-83c1-11e9-9385-7418069095d0.png">

Goes with [this server branch](https://github.com/NYPL-Simplified/library_registry/pull/119).

The purpose of this branch is to add an optional "Areas" tab to the tabs in the library detail view (optional because if the library doesn't have any data about areas, there's no point displaying a blank tab; better to just leave the tab off).

While trying to update all of the tests that were suddenly complaining because their sample library data didn't reflect the change to the library interface, I got fed up and created a `library-data` file from which all of the tests can import sample library objects.  (It's the same library objects that the tests were already using; it's just that now they live in their own file rather than being copy-pasted into every single test.  Reusable stuff for the win!!!)  There is room for several other test improvements along similar lines, but this isn't the branch for them.