### PR TITLE
Update label on search form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.3.2
+#### Updated
+- Changed the label on the search form to reflect new functionality.
+
 ### v1.3.1
 #### Added
 - Enabled filtering the list of libraries by attribute.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/LibrariesPage.tsx
+++ b/src/components/LibrariesPage.tsx
@@ -57,7 +57,7 @@ export class LibrariesPage extends React.Component<LibrariesPageProps, Libraries
     let searchForm: JSX.Element = <SearchForm
       search={this.search}
       term={this.state.searchTerm}
-      text="Search for a library by name"
+      text="Search for a library by name, keyword, or location."
       inputName="name"
       clear={!this.state.showAll ? this.clear : null}
       resultsCount={libraries && libraries.length}

--- a/src/components/__tests__/LibrariesPage-test.tsx
+++ b/src/components/__tests__/LibrariesPage-test.tsx
@@ -118,7 +118,7 @@ describe("LibrariesPage", () => {
     expect(wrapper.render().hasClass("libraries-page")).to.be.true;
     let searchForm = wrapper.find(SearchForm);
     expect(searchForm.length).to.equal(1);
-    expect(searchForm.find(".panel-title").text()).to.equal("Search for a library by name");
+    expect(searchForm.find(".panel-title").text()).to.equal("Search for a library by name, keyword, or location.");
     expect(searchForm.find(".btn").length).to.equal(1);
     wrapper.setState({ showAll: false });
 


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2200.  Makes sense in context of https://github.com/NYPL-Simplified/library_registry/pull/131 (and shouldn't be published until that one is ready).  The server branch makes it so you can search for libraries by attributes other than name; search form shouldn't just say "search by name" anymore.

<img width="1097" alt="Screen Shot 2019-08-06 at 4 23 33 PM" src="https://user-images.githubusercontent.com/42178216/62574470-8f306800-b866-11e9-8309-28a5c3bf9ed6.png">
