### PR TITLE
Add LoadingIndicator to LibrariesList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.3.3
+#### Added
+- Rendered a loading indicator component while the list of libraries is being loaded.
+
 ### v1.3.2
 #### Updated
 - Changed the label on the search form to reflect new functionality.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/LibrariesList.tsx
+++ b/src/components/LibrariesList.tsx
@@ -3,24 +3,29 @@ import { Store } from "redux";
 import { State } from "../reducers/index";
 import { LibraryData } from "../interfaces";
 import LibrariesListItem from "./LibrariesListItem";
+import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
 
 export interface LibrariesListOwnProps {
   libraries?: LibraryData[];
   store?: Store<State>;
+  isLoaded: boolean;
 }
 
 export default class LibrariesList extends React.Component<LibrariesListOwnProps, {}> {
   render(): JSX.Element {
-    return (this.props.libraries ?
-            <ul className="list">
-              { this.props.libraries.map(library =>
-                <LibrariesListItem
-                  key={library.uuid}
-                  library={library}
-                  store={this.props.store}
-                />) }
-            </ul> :
-            <span>There are no libraries in this registry yet.</span>
-          );
+    return (
+      !this.props.isLoaded ?
+        <LoadingIndicator /> :
+        this.props.libraries ?
+          <ul className="list">
+            { this.props.libraries.map(library =>
+              <LibrariesListItem
+                key={library.uuid}
+                library={library}
+                store={this.props.store}
+              />) }
+          </ul> :
+          <span>There are no libraries in this registry yet.</span>
+    );
   }
 }

--- a/src/components/LibrariesPage.tsx
+++ b/src/components/LibrariesPage.tsx
@@ -13,6 +13,7 @@ export interface LibrariesPageStateProps {
   libraries?: LibrariesData;
   results?: LibrariesData;
   updatedLibrary?: LibraryData;
+  isLoaded?: boolean;
 }
 
 export interface LibrariesPageOwnProps {
@@ -71,7 +72,6 @@ export class LibrariesPage extends React.Component<LibrariesPageProps, Libraries
     />;
 
     let toggle: JSX.Element = <Toggle onToggle={this.toggleQA} initialOn={this.state.qa} label="QA Mode" />;
-
     return (
       <div className="libraries-page">
         { toggle }
@@ -80,6 +80,7 @@ export class LibrariesPage extends React.Component<LibrariesPageProps, Libraries
         <LibrariesList
           libraries={libraries}
           store={this.props.store}
+          isLoaded={this.props.isLoaded}
         />
       </div>
     );
@@ -218,7 +219,8 @@ function mapStateToProps(state: State, ownProps: LibrariesPageOwnProps) {
   return {
     libraries: state.libraries && state.libraries.data,
     updatedLibrary: state.library && state.library.data,
-    results: state.results && state.results.data
+    results: state.results && state.results.data,
+    isLoaded: state.libraries && state.libraries.isLoaded
   };
 }
 

--- a/src/components/__tests__/LibrariesList-test.tsx
+++ b/src/components/__tests__/LibrariesList-test.tsx
@@ -7,6 +7,7 @@ import { testLibrary1, testLibrary2, modifyLibrary } from "./TestUtils";
 
 import LibrariesList from "../LibrariesList";
 import LibrariesListItem from "../LibrariesListItem";
+import LoadingIndicator from "opds-web-client/lib/components/LoadingIndicator";
 
 describe("LibrariesList", () => {
   const libraries = [testLibrary1, testLibrary2];
@@ -20,6 +21,7 @@ describe("LibrariesList", () => {
         <LibrariesList
           store={store}
           libraries={libraries}
+          isLoaded={true}
         />
       );
     });
@@ -50,6 +52,16 @@ describe("LibrariesList", () => {
       let message = wrapper.find("span");
       expect(message.length).to.equal(1);
       expect(message.text()).to.equal("There are no libraries in this registry yet.");
+    });
+
+    it("should display a loading indicator while the list of libraries is loading", () => {
+      let loader = wrapper.find(LoadingIndicator);
+      expect(loader.length).to.equal(0);
+      wrapper.setProps({ isLoaded: false });
+      loader = wrapper.find(LoadingIndicator);
+      expect(loader.length).to.equal(1);
+      // Don't show the "There are no libraries" message.
+      expect(wrapper.find("span").length).to.equal(0);
     });
   });
 });

--- a/src/components/__tests__/LibrariesPage-test.tsx
+++ b/src/components/__tests__/LibrariesPage-test.tsx
@@ -13,29 +13,7 @@ import { Form } from "library-simplified-reusable-components";
 
 describe("LibrariesPage", () => {
   let libraries;
-
-  let qaLib = {
-    uuid: "UUID3",
-    basic_info: {
-      "name": "QA Library",
-      "short_name": "qa",
-    },
-    urls_and_contact: {
-      "authentication_url": "qaURL",
-      "contact_email": "qaEmail",
-      "opds_url": "qaOpds",
-      "web_url": "qaWeb"
-    },
-    stages: {
-      "library_stage": "testing",
-      "registry_stage": "testing"
-    },
-    areas: {
-      "focus": [],
-      "service": []
-    }
-  };
-
+  let qaLib = modifyLibrary(testLibrary1, { "name": "QA Library", "uuid": "UUID3"});
   let fetchData;
   let fetchQA;
   let search;
@@ -58,6 +36,7 @@ describe("LibrariesPage", () => {
         fetchQA={fetchQA}
         search={search}
         libraries={{libraries}}
+        isLoaded={true}
       />
     );
   });
@@ -280,4 +259,11 @@ describe("LibrariesPage", () => {
     expect(wrapper.instance().convertToAttrName("Basic Info")).to.equal("basic_info");
   });
 
+  it("should let the LibrariesList know whether the list of libraries has finished loading", () => {
+    let list = wrapper.find(LibrariesList);
+    expect(list.prop("isLoaded")).to.be.true;
+    wrapper.setProps({ isLoaded: false });
+    list = wrapper.find(LibrariesList);
+    expect(list.prop("isLoaded")).to.be.false;
+  });
 });


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2026; shows LoadingIndicator (instead of inaccurate "There are no libraries in this registry" message) when the page first loads, and when the user first toggles QA mode on.