### PR TITLE
Adding unique id as library name for each PlsIDForm component that ge…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 #### Added
 - Typedoc for generating code documentation.
 #### Updated
-- Updated the Panel components to take in new props and using the Header from Reusable Components.
-- Updating the PlsIDForm to use an Id prop to render unique Ids on the page.
+- Updated the Panel components to take in new props and used the Header from Reusable Components.
+- Updated the PlsIDForm to use the `uuid` prop as an ID to its `Input` component for accessibility purposes.
 
 ### v1.3.3
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Typedoc for generating code documentation.
 #### Updated
 - Updated the Panel components to take in new props and using the Header from Reusable Components.
+- Updating the PlsIDForm to use an Id prop to render unique Ids on the page.
 
 ### v1.3.3
 #### Added

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -125,7 +125,6 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
           currentID={library.basic_info.pls_id}
           fetchLibrary={this.props.fetchLibrary}
           uuid={library.uuid}
-          libraryName={library.basic_info.name}
         />
         <hr />
         <div className="detail-content">

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -120,7 +120,13 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
           fetchLibrary={this.props.fetchLibrary}
         />
         <hr />
-        <PlsIDForm store={this.props.store} currentID={library.basic_info.pls_id} fetchLibrary={this.props.fetchLibrary} uuid={library.uuid} />
+        <PlsIDForm
+          store={this.props.store}
+          currentID={library.basic_info.pls_id}
+          fetchLibrary={this.props.fetchLibrary}
+          uuid={library.uuid}
+          libraryName={library.basic_info.name}
+        />
         <hr />
         <div className="detail-content">
           <Tabs items={tabItems}/>

--- a/src/components/PlsIDForm.tsx
+++ b/src/components/PlsIDForm.tsx
@@ -13,6 +13,7 @@ export interface PlsIDFormOwnProps {
   uuid: string;
   store: Store<State>;
   fetchLibrary: (uuid: string) => LibraryData;
+  libraryName: string;
   currentID?: string;
 }
 
@@ -50,14 +51,20 @@ export class PlsIDForm extends React.Component<PlsIDFormProps, PlsIDState> {
     let isSaved = this.state.saved && !this.props.error;
     let icon = isSaved ? <CheckSoloIcon /> : null;
     let buttonText = isSaved ? "Saved" : "Save";
-    return(
+    let plsInput = <Input
+        key="pls"
+        name="pls_id"
+        value={this.props.currentID}
+        id={`${this.props.libraryName.replace(/ /g, "")}-id`}
+      />;
+    return (
       <Form
         className="border pls-id"
         title="PLS ID"
         buttonClass={`left-align top-align bottom-align ${isSaved && "success"}`}
         buttonContent={<span>{buttonText}{icon}</span>}
         onSubmit={this.submit}
-        content={<Input key="pls" name="pls_id" value={this.props.currentID} />}
+        content={plsInput}
         hiddenName="uuid"
         hiddenValue={this.props.uuid}
         errorText={this.props.error ? this.props.error.response : null}

--- a/src/components/PlsIDForm.tsx
+++ b/src/components/PlsIDForm.tsx
@@ -13,7 +13,6 @@ export interface PlsIDFormOwnProps {
   uuid: string;
   store: Store<State>;
   fetchLibrary: (uuid: string) => LibraryData;
-  libraryName: string;
   currentID?: string;
 }
 
@@ -55,7 +54,7 @@ export class PlsIDForm extends React.Component<PlsIDFormProps, PlsIDState> {
         key="pls"
         name="pls_id"
         value={this.props.currentID}
-        id={`${this.props.libraryName.replace(/ /g, "")}-id`}
+        id={this.props.uuid}
       />;
     return (
       <Form

--- a/src/components/__tests__/PlsIDForm-test.tsx
+++ b/src/components/__tests__/PlsIDForm-test.tsx
@@ -16,7 +16,9 @@ describe("PlsIDForm", () => {
     store = buildStore();
     fetchLibrary = Sinon.stub();
     postPlsID = Sinon.stub();
-    wrapper = Enzyme.mount(<PlsIDForm store={store} fetchLibrary={fetchLibrary} postPlsID={postPlsID} uuid={testLibrary1.uuid} />);
+    wrapper = Enzyme.mount(
+      <PlsIDForm libraryName="name1" store={store} fetchLibrary={fetchLibrary} postPlsID={postPlsID} uuid={testLibrary1.uuid} />
+    );
   });
 
   it("renders a form with a title, info message, hidden input field, text input field, and button", () => {
@@ -36,6 +38,7 @@ describe("PlsIDForm", () => {
     let textInput = wrapper.find("input").at(1);
     expect(textInput.prop("type")).to.equal("text");
     expect(textInput.prop("name")).to.equal("pls_id");
+    expect(textInput.prop("id")).to.equal("name1-id");
 
     let button = wrapper.find("button");
     expect(button.text()).to.equal("Save");

--- a/src/components/__tests__/PlsIDForm-test.tsx
+++ b/src/components/__tests__/PlsIDForm-test.tsx
@@ -17,7 +17,7 @@ describe("PlsIDForm", () => {
     fetchLibrary = Sinon.stub();
     postPlsID = Sinon.stub();
     wrapper = Enzyme.mount(
-      <PlsIDForm libraryName="name1" store={store} fetchLibrary={fetchLibrary} postPlsID={postPlsID} uuid={testLibrary1.uuid} />
+      <PlsIDForm store={store} fetchLibrary={fetchLibrary} postPlsID={postPlsID} uuid={testLibrary1.uuid} />
     );
   });
 
@@ -38,7 +38,7 @@ describe("PlsIDForm", () => {
     let textInput = wrapper.find("input").at(1);
     expect(textInput.prop("type")).to.equal("text");
     expect(textInput.prop("name")).to.equal("pls_id");
-    expect(textInput.prop("id")).to.equal("name1-id");
+    expect(textInput.prop("id")).to.equal(testLibrary1.uuid);
 
     let button = wrapper.find("button");
     expect(button.text()).to.equal("Save");


### PR DESCRIPTION
Attempting to resolve [SIMPLY-2231](https://jira.nypl.org/browse/SIMPLY-2232).
This and more accessibility come up when using axe. This PR is just for the PlsIDForm and uses the library's name to create a unique id. That should be unique enough.

<img width="719" alt="Screen Shot 2019-08-21 at 10 29 43 AM" src="https://user-images.githubusercontent.com/1280564/63441491-7e9ff600-c3ff-11e9-916d-64a5c3826b33.png">
