### PR TITLE
Fixing accessibility issues found by react-axe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.3.11
+#### Fixed
+- Fixed accessibility issues found by `react-axe`.
+
 ### v1.3.10
 #### Added
 - Added `react-axe` to test for accessibility.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -38,14 +38,16 @@ export default class App extends React.Component<AppProps, {}> {
           logOut="/admin/log_out"
           loggedIn={!!username}
         />
-        <Route
-          path="/admin"
-          render={() => (
-            username ?
-              <LibrariesListContainer /> :
-              <LogInForm store={store} />
-          )}
-        />
+        <main>
+          <Route
+            path="/admin"
+            render={() => (
+              username ?
+                <LibrariesListContainer /> :
+                <LogInForm store={store} />
+            )}
+          />
+        </main>
       </div>
     );
   }

--- a/src/components/Charts.tsx
+++ b/src/components/Charts.tsx
@@ -4,22 +4,30 @@ import { LibraryData } from "../interfaces";
 
 export interface ChartsProps {
   data: {[key: string]: LibraryData[]};
+  width?: string | number;
+  height?: string | number;
 }
 
 export default class Charts extends React.Component<ChartsProps, {}> {
+  static defaultProps = {
+    width: "50%",
+    height: 400
+  };
+
   render() {
     const colors = {
       "production": "#809F69",
       "testing": "#FFCD61",
       "cancelled": "#DA5D62"
     };
+    const { width, height } = this.props;
     let chartData = Object.keys(this.props.data).map((category) => {
       return { "name": category, "value": this.props.data[category].length };
     });
 
     return (
         <div className="chart-view">
-          <ResponsiveContainer width={400} height={400}>
+          <ResponsiveContainer width={width} height={height}>
             <PieChart ref="pie-chart-svg">
               <Legend
                 payload={ chartData.map(
@@ -40,7 +48,7 @@ export default class Charts extends React.Component<ChartsProps, {}> {
               <Tooltip />
             </PieChart>
           </ResponsiveContainer>
-          <ResponsiveContainer width={400} height={400}>
+          <ResponsiveContainer width={width} height={height}>
             <BarChart ref="bar-chart-svg" width={400} height={400} data={chartData}>
               <CartesianGrid strokeDasharray="5 5" />
               <XAxis dataKey="name" interval={0} />

--- a/src/components/LibraryStageItem.tsx
+++ b/src/components/LibraryStageItem.tsx
@@ -15,7 +15,7 @@ export default class LibraryStageItem extends React.Component<LibraryStageItemPr
     const { label, value } = this.props;
 
     let select = (
-      <select key={label} name={label} defaultValue={value}>
+      <select key={label} name={label} defaultValue={value} aria-label={`Select ${label}`}>
         <option value="testing" aria-selected={value === "testing"}>Testing</option>
         <option value="production" aria-selected={value === "production"}>Production</option>
         <option value="cancelled" aria-selected={value === "cancelled"}>Cancelled</option>

--- a/src/components/__tests__/AggregateList-test.tsx
+++ b/src/components/__tests__/AggregateList-test.tsx
@@ -12,6 +12,8 @@ describe("AggregateList", () => {
   let data;
   let productionLibrary1 = modifyLibrary(testLibrary1, { "name": "Production Library 1", "registry_stage": "production" });
   let productionLibrary2 = modifyLibrary(productionLibrary1, { "name": "Production Library 2" });
+  productionLibrary2.uuid = "UUID2";
+
   beforeEach(() => {
     data = {
       "production": [productionLibrary1, productionLibrary2],

--- a/src/components/__tests__/Charts-test.tsx
+++ b/src/components/__tests__/Charts-test.tsx
@@ -16,7 +16,7 @@ describe("Charts", () => {
       "testing": [testLibrary1],
       "cancelled": [testLibrary2]
     };
-    wrapper = Enzyme.mount(<Charts data={data} />);
+    wrapper = Enzyme.mount(<Charts data={data} width={400} />);
   });
   it("renders a pie chart", () => {
     let pieChart = wrapper.find(".chart-view").children().at(0).find(".recharts-wrapper");

--- a/src/components/__tests__/LibraryStageItem-test.tsx
+++ b/src/components/__tests__/LibraryStageItem-test.tsx
@@ -40,6 +40,11 @@ describe("LibraryStageItem", () => {
     expect(options.at(1).html()).to.contain("Production");
     expect(options.at(2).html()).to.contain("Cancelled");
   });
+  it("should have an aria-label", () => {
+    let select = wrapper.find("select");
+
+    expect(select.prop("aria-label")).to.equal(`Select ${label}`);
+  });
   it("should update when the value prop changes", () => {
     wrapper.setProps({ value: "production" });
 

--- a/src/components/__tests__/Toggle-test.tsx
+++ b/src/components/__tests__/Toggle-test.tsx
@@ -66,7 +66,6 @@ describe("Toggle", () => {
 
   it("should have an aria-label", () => {
     let slider = wrapper.find("button");
-
     expect(slider.prop("aria-label")).to.equal("Toggle button");
   });
 });

--- a/src/components/__tests__/Toggle-test.tsx
+++ b/src/components/__tests__/Toggle-test.tsx
@@ -63,4 +63,10 @@ describe("Toggle", () => {
     expect(onToggle.args[1][0]).to.be.false;
     isOn(false);
   });
+
+  it("should have an aria-label", () => {
+    let slider = wrapper.find("button");
+
+    expect(slider.prop("aria-label")).to.equal("Toggle button");
+  });
 });

--- a/src/components/reusables/Toggle.tsx
+++ b/src/components/reusables/Toggle.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 
 export interface ToggleOwnProps {
   onToggle: (status: boolean, name?: string) => void;
@@ -33,7 +32,13 @@ export default class Toggle extends React.Component<ToggleOwnProps, ToggleState>
       <form className="toggle-container">
         { label && <label className={this.state.on ? "active" : ""}><span>{label}</span></label> }
         <div className={`toggle${this.state.on ? " toggle-on" : ""}`}>
-          <button tabIndex={0} className={`slider${this.state.on ? " slider-on" : ""}`} aria-pressed={this.state.on} onClick={this.toggle} />
+          <button
+            tabIndex={0}
+            className={`slider${this.state.on ? " slider-on" : ""}`}
+            aria-label="Toggle button"
+            aria-pressed={this.state.on}
+            onClick={this.toggle}
+          />
         </div>
       </form>
     );


### PR DESCRIPTION
Resolves [SIMPLY-2384](https://jira.nypl.org/browse/SIMPLY-2384). Fixes some issues found. There are some color contrast issues that react-axe picks up but they are in transitional states for panel headings but I think it's false since some of those colors don't even exist. Maybe it picks up a shade of color _during_ a hover transition.

As an aside, `recharts` throws a lot of warnings in the console (which didn't before!). I fixed one about having "400" as width and height in the `ResponsiveContainer` component. The [documentation](http://recharts.org/en-US/api/ResponsiveContainer) says one of those props needs to be a percentage. Unfortunately, if one prop is a percentage, it doesn't seem to mount in tests so I made it so, only for those specific tests, it's a static width and height. This will be nice to look into but I didn't want to spend too much time on it, and you are more familiar with it so you may know what the better fix is. According to the warning, if you're using 400 for both height and width, then you may not even need `ResponsiveContainer`, which may be the case from the screenshots.
400 x 400:
![Screen Shot 2019-11-07 at 4 11 05 PM](https://user-images.githubusercontent.com/1280564/68430364-f1f31180-017d-11ea-9639-6f0e6a4d02b9.png)

50% x 400:
![Screen Shot 2019-11-07 at 4 10 16 PM](https://user-images.githubusercontent.com/1280564/68430372-f61f2f00-017d-11ea-86bb-c1cad3bffc9f.png)

I also reduced some output from the `AggregateList` tests which was because both libraries in the tests had the same uuid. I had to do this:
```
let productionLibrary2 = modifyLibrary(productionLibrary1, { "name": "Production Library 2" });
productionLibrary2.uuid = "UUID2";
```
because `modifyLibrary` doesn't update a value that is a root value. Honestly, this is an issue with the test and not updating the test data correctly and shouldn't be a problem in real life.