### PR TITLE
Get geographic info from PLS ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.4.2
+#### Updated
+- Enabled the Aggregate Data panel to pull geographical information from PLS IDs when necessary. 
+
 ### v1.4.1
 #### Added
 - Implemented option for displaying geographical information alongside each library's name in the List tab of the Aggregate Data panel.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/AggregateList.tsx
+++ b/src/components/AggregateList.tsx
@@ -121,17 +121,17 @@ export default class AggregateList extends React.Component<AggregateListProps, A
     let libraries = this.props.data[category];
     return libraries.map((l) => {
       return (
-        <li className="inner-stats-item" key={l.uuid}><p>{l.basic_info.name}{this.getGeographicInfo(l.areas)}</p></li>
+        <li className="inner-stats-item" key={l.uuid}><p>{l.basic_info.name}{this.getGeographicInfo(l)}</p></li>
       );
     });
   }
 
-  getGeographicInfo(areas: { [key: string]: string[] }): string {
+  getGeographicInfo(library: LibraryData): string {
     if (!this.state.geographicInfo) {
       return "";
     }
     let areaString: string = "";
-    let allAreas: string[] = areas.focus.concat(areas.service);
+    let allAreas: string[] = library.areas.focus.concat(library.areas.service);
     allAreas.forEach((a: string) => {
       // Each string is in the format "Zip code/city, (state abbreviation)".  We're just interested in the state abbreviation
       // right now, so we get it by pulling out any two-letter sequence between parentheses.
@@ -150,6 +150,11 @@ export default class AggregateList extends React.Component<AggregateListProps, A
         areaString += `${areaString.length ? ", " : ""}${match[1]}`;
       }
     });
+    // If we couldn't get any information from the areas, we see whether we know the library's PLS ID;
+    // the first two characters of the PLS ID are the state abbreviation.
+    if (!areaString.length && library.basic_info.pls_id) {
+      areaString += library.basic_info.pls_id && library.basic_info.pls_id.slice(0, 2);
+    }
     return (areaString.length && ` (${areaString})`) || " (state unknown)";
   }
 

--- a/src/components/__tests__/AggregateList-test.tsx
+++ b/src/components/__tests__/AggregateList-test.tsx
@@ -182,6 +182,9 @@ describe("AggregateList", () => {
     expect(nameLists.at(2).text()).not.to.contain("(state unknown)");
   });
   it("generates a string based on the library's areas", () => {
+    let info = (attr: {[index: string]: string[]}) =>
+      wrapper.instance().getGeographicInfo(modifyLibrary(testLibrary1, attr));
+
     wrapper.setState({ geographicInfo: true });
     let empty = { focus: [], service: [] };
     let oneFocusArea = { focus: ["11104 (NY)"], service: [] };
@@ -194,8 +197,6 @@ describe("AggregateList", () => {
     let oneUnknown = { focus: ["(unknown)"], service: ["11104 (NY)"] };
     let allUnknown = { focus: ["unknown"], service: ["unknown"] };
 
-    let info = wrapper.instance().getGeographicInfo;
-
     expect(info(empty)).to.equal(" (state unknown)");
     expect(info(oneFocusArea)).to.equal(" (NY)");
     expect(info(multipleFocusAreas)).to.equal(" (NY, NJ, CT)");
@@ -206,5 +207,9 @@ describe("AggregateList", () => {
     expect(info(withDuplicates)).to.equal(" (CT)");
     expect(info(oneUnknown)).to.equal(" (NY)");
     expect(info(allUnknown)).to.equal(" (state unknown)");
+
+    expect(wrapper.instance().getGeographicInfo(
+      modifyLibrary(testLibrary2, { pls_id: "NY0778" }, "basic_info")
+    )).to.equal(" (NY)");
   });
 });


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2423.

I noticed that, on production, a LOT of libraries don't have any information in the areas attribute.  But many of them have the PLS ID listed.  First two characters of PLS ID == state abbreviation.