### PR TITLE
Sort by year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.4.4
+#### Added
+- Added a Yearly Data tab to the Stats panel, displaying a list of the libraries sorted by what year they were added.
+
 ### v1.4.3
 #### Updated
 - Updated the `opds-web-client` to version 0.3.2 and removing LibrariesListContainer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -28,7 +28,6 @@ export default class Stats extends React.Component<StatsProps, {}> {
       <Panel
         id="stats"
         headerText={"Aggregate Data"}
-        openByDefault={true}
         content={
           <div className="stats-panel">
             <Tabs items={tabItems} uniqueId="stats-tabs"/>

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -4,6 +4,7 @@ import { LibraryData } from "../interfaces";
 import AggregateList from "./AggregateList";
 import Charts from "./Charts";
 import AdobeTab from "./AdobeTab";
+import YearlyDataTab from "./YearlyDataTab";
 
 export interface StatsProps {
   libraries?: LibraryData[];
@@ -20,12 +21,14 @@ export default class Stats extends React.Component<StatsProps, {}> {
     let tabItems = {
       "List": <AggregateList data={sorted} />,
       "Charts": <Charts data={sorted} />,
-      "Adobe Data": <AdobeTab data={sorted.production} />
+      "Adobe Data": <AdobeTab data={sorted.production} />,
+      "Yearly Data": <YearlyDataTab data={sorted} />
     };
     return (
       <Panel
         id="stats"
         headerText={"Aggregate Data"}
+        openByDefault={true}
         content={
           <div className="stats-panel">
             <Tabs items={tabItems} uniqueId="stats-tabs"/>

--- a/src/components/YearlyDataTab.tsx
+++ b/src/components/YearlyDataTab.tsx
@@ -40,12 +40,11 @@ export default class YearlyDataTab extends React.Component<YearlyDataTabProps, Y
     this.setState({ styled: !this.state.styled });
   }
   render(): JSX.Element {
-    let hasStyles = this.state.styled;
-    let categories = (year) => <ul>{Object.keys(year).map(c => <li><p>{c.substr(0, 1).toUpperCase() + c.substr(1)}</p>{names(year[c])}</li>)}</ul>;
+    let categories = (year) => <ul>{Object.keys(year).map(c => <li className={this.state.styled ? "stats-category" : ""}><p className="stats-category-name">{c.substr(0, 1).toUpperCase() + c.substr(1)}</p>{names(year[c])}</li>)}</ul>;
     let names = (category) => <ul className="yearly-library-list">{category.map(l => <li>{l}</li>)}</ul>;
     let sortedByYear = this.sortByYear(this.props.data);
     let years = Object.keys(sortedByYear).map(y =>
-      <li key={y} className={hasStyles ? "year-li" : ""}><p>{y}</p>{categories(sortedByYear[y])}</li>
+      <li key={y} className={this.state.styled ? "year-li" : ""}><p>{y}</p>{categories(sortedByYear[y])}</li>
     );
     return (
       <div className="yearly-data">

--- a/src/components/YearlyDataTab.tsx
+++ b/src/components/YearlyDataTab.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import CopyButton from "./CopyButton";
+import { Button } from "library-simplified-reusable-components";
+import { LibraryData } from "../interfaces";
+
+export interface YearlyDataTabProps {
+  data: {[key: string]: LibraryData[]};
+}
+
+export interface YearlyDataTabState {
+  styled: boolean;
+}
+
+export default class YearlyDataTab extends React.Component<YearlyDataTabProps, YearlyDataTabState> {
+  private dataRef = React.createRef<HTMLUListElement>();
+  constructor(props: YearlyDataTabProps) {
+    super(props);
+    this.state = { styled: true };
+    this.toggleFormatting = this.toggleFormatting.bind(this);
+  }
+  sortByYear(data) {
+    let sortedByYear = {};
+    Object.keys(data).map((name: string) => {
+      let category = data[name];
+      category.forEach((library) => {
+        let year = library.basic_info.timestamp && library.basic_info.timestamp.match(/20\d+/)[0];
+        if (year) {
+          if (sortedByYear[year]) {
+            sortedByYear[year][name].push(library.basic_info.name);
+          } else {
+            sortedByYear[year] = {"production": [], "testing": [], "cancelled": []};
+            sortedByYear[year][name].push(library.basic_info.name);
+          }
+        }
+      });
+    });
+    return(sortedByYear);
+  }
+  toggleFormatting() {
+    this.setState({ styled: !this.state.styled });
+  }
+  render(): JSX.Element {
+    let hasStyles = this.state.styled;
+    let categories = (year) => <ul>{Object.keys(year).map(c => <li><p>{c.substr(0, 1).toUpperCase() + c.substr(1)}</p>{names(year[c])}</li>)}</ul>;
+    let names = (category) => <ul className="yearly-library-list">{category.map(l => <li>{l}</li>)}</ul>;
+    let sortedByYear = this.sortByYear(this.props.data);
+    let years = Object.keys(sortedByYear).map(y =>
+      <li key={y} className={hasStyles ? "year-li" : ""}><p>{y}</p>{categories(sortedByYear[y])}</li>
+    );
+    return (
+      <div className="yearly-data">
+        <div className="buttons">
+          <Button
+            key="format"
+            callback={this.toggleFormatting}
+            content={`${this.state.styled ? "Remove" : "Restore"} Formatting`}
+            className="inline squared inverted left-align"
+          />
+          <CopyButton element={this.dataRef.current} />
+        </div>
+        <ul
+          ref={this.dataRef}
+          contentEditable
+          suppressContentEditableWarning
+        >
+          {years}
+        </ul>
+      </div>
+    );
+  }
+}

--- a/src/components/YearlyDataTab.tsx
+++ b/src/components/YearlyDataTab.tsx
@@ -20,16 +20,16 @@ export default class YearlyDataTab extends React.Component<YearlyDataTabProps, Y
   }
   sortByYear(data) {
     let sortedByYear = {};
-    Object.keys(data).map((name: string) => {
-      let category = data[name];
+    Object.keys(data).forEach((catName: string) => {
+      let category = data[catName];
       category.forEach((library) => {
         let year = library.basic_info.timestamp && library.basic_info.timestamp.match(/20\d+/)[0];
         if (year) {
           if (sortedByYear[year]) {
-            sortedByYear[year][name].push(library.basic_info.name);
+            sortedByYear[year][catName].push(library.basic_info.name);
           } else {
             sortedByYear[year] = {"production": [], "testing": [], "cancelled": []};
-            sortedByYear[year][name].push(library.basic_info.name);
+            sortedByYear[year][catName].push(library.basic_info.name);
           }
         }
       });
@@ -40,7 +40,7 @@ export default class YearlyDataTab extends React.Component<YearlyDataTabProps, Y
     this.setState({ styled: !this.state.styled });
   }
   render(): JSX.Element {
-    let categories = (year) => <ul>{Object.keys(year).map(c => <li className={this.state.styled ? "stats-category" : ""}><p className="stats-category-name">{c.substr(0, 1).toUpperCase() + c.substr(1)}</p>{names(year[c])}</li>)}</ul>;
+    let categories = (year) => <ul>{Object.keys(year).map(category => <li className={this.state.styled ? "stats-category" : ""}><p className="stats-category-name">{category.substr(0, 1).toUpperCase() + category.substr(1)}</p>{names(year[category])}</li>)}</ul>;
     let names = (category) => <ul className="yearly-library-list">{category.map(l => <li>{l}</li>)}</ul>;
     let sortedByYear = this.sortByYear(this.props.data);
     let years = Object.keys(sortedByYear).map(y =>

--- a/src/components/__tests__/LibraryDetailPage-test.tsx
+++ b/src/components/__tests__/LibraryDetailPage-test.tsx
@@ -44,14 +44,16 @@ describe("LibraryDetailPage", () => {
 
     expect(basicInfoCall.args[0]).to.equal(library.basic_info);
     expect(basicInfoCall.returnValue.type).to.equal("ul");
-    expect(basicInfoCall.returnValue.props.children.length).to.equal(3);
-    let [name, short_name, number_of_patrons] = basicInfoCall.returnValue.props.children;
+    expect(basicInfoCall.returnValue.props.children.length).to.equal(4);
+    let [name, short_name, number_of_patrons, timestamp] = basicInfoCall.returnValue.props.children;
     expect(name.props.label).to.equal("name");
     expect(name.props.value).to.equal("Test Library 1");
     expect(short_name.props.label).to.equal("short_name");
     expect(short_name.props.value).to.equal("lib1");
     expect(number_of_patrons.props.label).to.equal("number_of_patrons");
     expect(number_of_patrons.props.value).to.equal("3");
+    expect(timestamp.props.label).to.equal("timestamp");
+    expect(timestamp.props.value).to.equal("Fri, 01 Nov 2019 15:05:34 GMT");
 
     expect(urlsContactCall.args[0]).to.equal(library.urls_and_contact);
     expect(urlsContactCall.returnValue.type).to.equal("ul");
@@ -81,7 +83,7 @@ describe("LibraryDetailPage", () => {
     expect(list.length).to.equal(3);
 
     let basicInfoItems = list.at(0).find("li");
-    expect(basicInfoItems.length).to.equal(3);
+    expect(basicInfoItems.length).to.equal(4);
 
     let contactUrlItems = list.at(1).find("li");
     expect(contactUrlItems.length).to.equal(4);

--- a/src/components/__tests__/Stats-test.tsx
+++ b/src/components/__tests__/Stats-test.tsx
@@ -8,6 +8,7 @@ import Stats from "../Stats";
 import AggregateList from "../AggregateList";
 import Charts from "../Charts";
 import AdobeTab from "../AdobeTab";
+import YearlyDataTab from "../YearlyDataTab";
 
 describe("Stats", () => {
   let wrapper;
@@ -27,6 +28,7 @@ describe("Stats", () => {
     expect(tabs.find(".tab-nav").at(0).text()).to.equal("List");
     expect(tabs.find(".tab-nav").at(1).text()).to.equal("Charts");
     expect(tabs.find(".tab-nav").at(2).text()).to.equal("Adobe Data");
+    expect(tabs.find(".tab-nav").at(3).text()).to.equal("Yearly Data");
   });
 
   it("sorts a list of libraries by their status", () => {
@@ -51,5 +53,10 @@ describe("Stats", () => {
   it("renders an AdobeTab component", () => {
     let adobeTab = wrapper.find(AdobeTab);
     expect(adobeTab.length).to.equal(1);
+  });
+
+  it("renders a YearlyDataTab component", () => {
+    let yearlyDataTab = wrapper.find(YearlyDataTab);
+    expect(yearlyDataTab.length).to.equal(1);
   });
 });

--- a/src/components/__tests__/TestUtils.ts
+++ b/src/components/__tests__/TestUtils.ts
@@ -9,7 +9,8 @@ export const testLibrary1: LibraryData = {
     "name": "Test Library 1",
     "short_name": "lib1",
     "description": undefined,
-    "number_of_patrons": "3"
+    "number_of_patrons": "3",
+    "timestamp": "Fri, 01 Nov 2019 15:05:34 GMT"
   },
   urls_and_contact: {
     "authentication_url": "auth1",
@@ -32,7 +33,8 @@ export const testLibrary2: LibraryData = {
   basic_info: {
     "name": "Test Library 2",
     "short_name": "lib2",
-    "number_of_patrons": "1"
+    "number_of_patrons": "1",
+    "timestamp": "Fri, 01 Nov 2018 15:05:34 GMT"
   },
   urls_and_contact: {
     "authentication_url": "auth2",

--- a/src/components/__tests__/YearlyDataTab-test.tsx
+++ b/src/components/__tests__/YearlyDataTab-test.tsx
@@ -1,0 +1,87 @@
+import { expect } from "chai";
+import * as Sinon from "sinon";
+import * as Enzyme from "enzyme";
+import * as React from "react";
+import YearlyDataTab from "../YearlyDataTab";
+import CopyButton from "../CopyButton";
+import { testLibrary1, testLibrary2, modifyLibrary } from "./TestUtils";
+
+describe("YearlyDataTab", () => {
+  let data;
+  let wrapper;
+  beforeEach(() => {
+    let productionLibrary1 = modifyLibrary(testLibrary1, { "name": "Production Library 1", "registry_stage": "production" });
+    let productionLibrary2 = modifyLibrary(productionLibrary1, { "name": "Production Library 2", "timestamp": "Fri, 01 Nov 2018 15:05:34 GMT" });
+    let testLibrary2 = modifyLibrary(testLibrary1, { "name": "Test Library 2", "timestamp": "Fri, 01 Nov 2017 15:05:34 GMT"});
+    data = {
+      "production": [productionLibrary1, productionLibrary2],
+      "testing": [testLibrary1, testLibrary2],
+      "cancelled": []
+    };
+    wrapper = Enzyme.mount(<YearlyDataTab data={data} />);
+  });
+  it("renders the data", () => {
+    let years = wrapper.find(".year-li");
+    expect(years.length).to.equal(3);
+
+    let hasCategories = (year) => {
+      expect(year.find(".stats-category-name").map(n => n.text())).to.eql(["Production", "Testing", "Cancelled"]);
+    };
+
+    let y2017 = years.at(0);
+    expect(y2017.find("p").at(0).text()).to.equal("2017");
+    let categories = y2017.find(".stats-category");
+    let production = categories.at(0);
+    expect(production.find(".yearly-library-list").find("li").length).to.equal(0);
+    let testing = categories.at(1);
+    expect(testing.find(".yearly-library-list").find("li").length).to.equal(1);
+    expect(testing.find(".yearly-library-list").find("li").text()).to.equal("Test Library 2");
+    let cancelled = categories.at(2);
+    expect(production.find(".yearly-library-list").find("li").length).to.equal(0);
+
+    let y2018 = years.at(1);
+    expect(y2018.find("p").at(0).text()).to.equal("2018");
+    categories = y2018.find(".stats-category");
+    hasCategories(y2018);
+    production = categories.at(0);
+    expect(production.find(".yearly-library-list").find("li").length).to.equal(1);
+    expect(production.find(".yearly-library-list").find("li").text()).to.equal("Production Library 2");
+    testing = categories.at(1);
+    expect(testing.find(".yearly-library-list").find("li").length).to.equal(0);
+    cancelled = categories.at(2);
+    expect(cancelled.find(".yearly-library-list").find("li").length).to.equal(0);
+
+    let y2019 = years.at(2);
+    expect(y2019.find("p").at(0).text()).to.equal("2019");
+    categories = y2019.find(".stats-category");
+    hasCategories(y2019);
+    production = categories.at(0);
+    expect(production.find(".yearly-library-list").find("li").length).to.equal(1);
+    expect(production.find(".yearly-library-list").find("li").text()).to.equal("Production Library 1");
+    testing = categories.at(1);
+    expect(testing.find(".yearly-library-list").find("li").length).to.equal(1);
+    expect(testing.find(".yearly-library-list").find("li").text()).to.equal("Test Library 1");
+    cancelled = categories.at(2);
+    expect(cancelled.find(".yearly-library-list").find("li").length).to.equal(0);
+  });
+
+  it("renders a CopyButton", () => {
+    let copyButton = wrapper.find(CopyButton);
+    expect(copyButton.length).to.equal(1);
+  });
+
+  it("removes and restores the formatting", () => {
+    let listItems = wrapper.find("ul").at(0).children("li");
+    expect(listItems.length).to.equal(3);
+    listItems.map(l => expect(l.hasClass("year-li")).to.be.true);
+    expect(wrapper.state()["styled"]).to.be.true;
+    let formattingButton = wrapper.find("button").at(0);
+    expect(formattingButton.text()).to.equal("Remove Formatting");
+    expect(formattingButton.text()).to.equal("Remove Formatting");
+    formattingButton.simulate("click");
+    listItems = wrapper.find("ul").at(0).children("li");
+    listItems.map(l => expect(l.hasClass("year-li")).to.be.false);
+    expect(wrapper.state()["styled"]).to.be.false;
+    expect(formattingButton.text()).to.equal("Restore Formatting");
+  });
+});

--- a/src/stylesheets/stats.scss
+++ b/src/stylesheets/stats.scss
@@ -149,9 +149,9 @@
   }
   .yearly-data {
     width: 85%;
-  }
-  .yearly-data > ul {
-    width: 100%;
+    > ul {
+      width: 100%;
+    }
   }
   .adobe-charts {
     svg.recharts-surface {

--- a/src/stylesheets/stats.scss
+++ b/src/stylesheets/stats.scss
@@ -52,6 +52,46 @@
       }
     }
   }
+  .stats-category {
+    padding: 5px 10px 0 0;
+    &:first-child > .stats-category-name {
+      background: darken($green-tint, 10);
+    }
+    &:nth-child(2) > .stats-category-name {
+      background: $yellow-tint;
+    }
+    &:last-child > .stats-category-name {
+      background: $red-error;
+    }
+    > .stats-category-name {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border: 1px solid $dark-gray;
+      margin-bottom: 0;
+      padding: 10px 20px;
+      font-size: 1em;
+      > span {
+        margin: 0;
+      }
+    }
+    .inner-stats-list {
+      padding: 10px 10px 10px 25px;
+      border-radius: 0;
+      border-left: 1px solid $dark-gray;
+      border-right: 1px solid $dark-gray;
+      border-bottom: 1px solid $dark-gray;
+    }
+  }
+
+  .yearly-data .stats-category {
+    padding: 0;
+    .stats-category-name {
+      border-top: 0;
+      border-left: 0;
+      border-right: 0;
+    }
+  }
 
   .list-view {
     .stats-list {
@@ -60,37 +100,6 @@
       padding: 10px 0;
       list-style: none;
       width: 60%;
-      .stats-category {
-        padding: 5px 10px 0 0;
-        &:first-child > .stats-category-name {
-          background: darken($green-tint, 10);
-        }
-        &:nth-child(2) > .stats-category-name {
-          background: $yellow-tint;
-        }
-        &:last-child > .stats-category-name {
-          background: $red-error;
-        }
-        > .stats-category-name {
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          border: 1px solid $dark-gray;
-          margin-bottom: 0;
-          padding: 10px 20px;
-          font-size: 1em;
-          > span {
-            margin: 0;
-          }
-        }
-        .inner-stats-list {
-          padding: 10px 10px 10px 25px;
-          border-radius: 0;
-          border-left: 1px solid $dark-gray;
-          border-right: 1px solid $dark-gray;
-          border-bottom: 1px solid $dark-gray;
-        }
-      }
       ul:not(.inner-stats-list) {
         list-style: none;
       }
@@ -129,20 +138,6 @@
           > li {
             margin: 8px 0;
             border: 1px solid $dark-gray;
-            p {
-              padding: 10px 20px;
-              font-size: 1em;
-              border-bottom: 1px solid $dark-gray;
-            }
-            &:first-child > p {
-              background: darken($green-tint, 10);
-            }
-            &:nth-child(2) > p {
-              background: $yellow-tint;
-            }
-            &:last-child > p {
-              background: $red-error;
-            }
             ul {
               list-style: circle;
               padding: 10px 10px 10px 25px;

--- a/src/stylesheets/stats.scss
+++ b/src/stylesheets/stats.scss
@@ -96,14 +96,14 @@
       }
     }
   }
-  .adobe-data {
+  .adobe-data, .yearly-data {
     ul {
       pointer-events: none;
       margin: 0;
       padding: 10px 0;
       list-style: none;
       width: 60%;
-      .adobe-data-li {
+      .adobe-data-li, .year-li {
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -112,7 +112,51 @@
         border: 1px solid $blue-dark;
         margin-bottom: 5px;
       }
+      .year-li {
+        display: block;
+        width: 100%;
+        padding: 0;
+        > p {
+          border-bottom: 1px solid $blue-dark;
+          margin: 0;
+          padding: 10px 20px;
+        }
+        > ul {
+          display: block;
+          background: $white;
+          width: 100%;
+          padding: 20px;
+          > li {
+            margin: 8px 0;
+            border: 1px solid $dark-gray;
+            p {
+              padding: 10px 20px;
+              font-size: 1em;
+              border-bottom: 1px solid $dark-gray;
+            }
+            &:first-child > p {
+              background: darken($green-tint, 10);
+            }
+            &:nth-child(2) > p {
+              background: $yellow-tint;
+            }
+            &:last-child > p {
+              background: $red-error;
+            }
+            ul {
+              list-style: circle;
+              padding: 10px 10px 10px 25px;
+            }
+          }
+        }
+      }
     }
+  }
+  .yearly-data {
+    width: 85%;
+  }
+  .yearly-data > ul {
+    width: 100%;
   }
   .adobe-charts {
     svg.recharts-surface {


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2450

Another tab in the Stats panel: sorts the list of libraries by what year they registered.

@EdwinGuzman This is time-sensitive; Andrew would like to have access to this data before the end of the year (and I'm out on Thursday and Friday).  I'm sure there's plenty of room for refactoring (and/or finally moving all of the stats stuff to its own page!), but unless you spot something that's a HUGE problem from a functionality standpoint, better to just merge this as soon as possible so he can grab the list, and then I'll go back and clean up the code afterwards.

<img width="1168" alt="Screen Shot 2019-12-23 at 4 11 20 PM" src="https://user-images.githubusercontent.com/42178216/71380856-e37e7f00-259e-11ea-9b5c-15ee45d69700.png">
