### PR TITLE
Display total number of Adobe IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.4.5
+#### Updated
+- Displayed the total number of Adobe IDs in the Adobe Data tab.
+
 ### v1.4.4
 #### Added
 - Added a Yearly Data tab to the Stats panel, displaying a list of the libraries sorted by what year they were added.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/AdobeTab.tsx
+++ b/src/components/AdobeTab.tsx
@@ -18,6 +18,15 @@ export default class AdobeTab extends React.Component<AdobeTabProps, AdobeTabSta
     super(props);
     this.state = { styled: true };
     this.toggleFormatting = this.toggleFormatting.bind(this);
+    this.total = this.total.bind(this);
+  }
+
+  total() {
+    let idCounts = this.props.data.map(l => parseInt(l.basic_info.number_of_patrons));
+    if (idCounts.length > 0) {
+      return idCounts.reduce((accum, next) => accum + next);
+    }
+    return 0;
   }
 
   render(): JSX.Element {
@@ -38,6 +47,7 @@ export default class AdobeTab extends React.Component<AdobeTabProps, AdobeTabSta
           contentEditable
           suppressContentEditableWarning
         >
+          <p className={this.state.styled && "adobe-total"}>Total Adobe IDs: {this.total()}</p>
           { this.props.data && this.props.data.map((library) => {
             let name = library.basic_info.name;
             let numberOfPatrons = parseInt(library.basic_info.number_of_patrons);

--- a/src/components/__tests__/AdobeTab-test.tsx
+++ b/src/components/__tests__/AdobeTab-test.tsx
@@ -16,6 +16,9 @@ describe("AdobeTab", () => {
   });
 
   it("renders the data", () => {
+    let total = wrapper.find("p");
+    expect(total.length).to.equal(1);
+    expect(total.text()).to.equal("Total Adobe IDs: 6");
     let listItems = wrapper.find("li");
     expect(listItems.length).to.equal(3);
     expect(listItems.at(0).text()).to.equal("Test Library 1: 3 (50%)");
@@ -39,12 +42,16 @@ describe("AdobeTab", () => {
   });
 
   it("removes and restores the formatting", () => {
+    let total = wrapper.find("p");
+    expect(total.hasClass("adobe-total")).to.be.true;
     let listItems = wrapper.find("li");
     listItems.map(l => expect(l.hasClass("adobe-data-li")).to.be.true);
     expect(wrapper.state()["styled"]).to.be.true;
     let formattingButton = wrapper.find("button").at(0);
     expect(formattingButton.text()).to.equal("Remove Formatting");
     formattingButton.simulate("click");
+    total = wrapper.find("p");
+    expect(total.hasClass("adobe-total")).to.be.false;
     listItems = wrapper.find("li");
     listItems.map(l => expect(l.hasClass("adobe-data-li")).to.be.false);
     expect(wrapper.state()["styled"]).to.be.false;

--- a/src/stylesheets/stats.scss
+++ b/src/stylesheets/stats.scss
@@ -207,7 +207,7 @@
   }
 }
 
-.copy-confirmation {
+.copy-confirmation, .adobe-total {
   display: inline-block;
   vertical-align: middle;
   background: $green-tint;
@@ -220,4 +220,13 @@
   &.visible {
     opacity: 1;
   }
+}
+
+.adobe-total {
+  opacity: 1;
+  background: $blue-dark;
+  border-color: $blue-dark;
+  color: $white;
+  width: 100%;
+  text-align: center;
 }


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2477: displays how many Adobe IDs there are across all the libraries.  (This feature has been requested by both Tony and Andrew, so I'd like to get it out the door quickly, if possible.)

<img width="690" alt="Screen Shot 2020-01-14 at 3 04 48 PM" src="https://user-images.githubusercontent.com/42178216/72378538-998d4280-36df-11ea-8296-1e87549facef.png">

It works with the Remove Formatting button (and with the Copy Data button):
<img width="486" alt="Screen Shot 2020-01-14 at 3 10 30 PM" src="https://user-images.githubusercontent.com/42178216/72378764-099bc880-36e0-11ea-9d9f-b787a0ccc777.png">
