### PR TITLE
Add months to yearly data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.4.7
+#### Added
+- Added an option for displaying the month each library was added, in the Yearly Data tab.
+
 ### v1.4.6
 #### Updated
 - Refactored and added additional features to the Yearly Data tab.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/__tests__/sharedFunctions-test.ts
+++ b/src/__tests__/sharedFunctions-test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { getPercentage } from "../utils/sharedFunctions";
+import { getPercentage, getMonth, toggleState } from "../utils/sharedFunctions";
 
 describe("getPercentage", () => {
   let outOf;
@@ -24,5 +24,25 @@ describe("getPercentage", () => {
   });
   it("rounds numbers", () => {
     expect(getPercentage(55, outOf)).to.equal(28);
+  });
+});
+
+describe("getMonth", () => {
+  it("takes a timestamp and returns the name of a month", () => {
+    expect(getMonth("Fri, 01 Nov 2019 15:05:34 GMT")).to.equal("November");
+    expect(getMonth("Mon, 19 Aug 2019 15:05:34 GMT")).to.equal("August");
+    expect(getMonth("Fri, 12 Apr 2019 15:05:34 GMT")).to.equal("April");
+  });
+});
+
+describe("toggleState", () => {
+  let state;
+  beforeEach(() => {
+    state = {"A": true, "B": false, "C": true};
+  });
+  it("takes an attribute and returns the updated state", () => {
+    expect(toggleState("A", state)).to.eql({ "A": false, "B": false, "C": true });
+    expect(toggleState("B", state)).to.eql({ "A": true, "B": true, "C": true });
+    expect(toggleState("C", state)).to.eql({ "A": true, "B": false, "C": false });
   });
 });

--- a/src/components/StatsInnerList.tsx
+++ b/src/components/StatsInnerList.tsx
@@ -7,6 +7,7 @@ export interface StatsInnerListProps {
   styled: boolean;
   stagesToShow?: {[ key: string ]: boolean};
   showGeographicInfo?: boolean;
+  showMonths?: boolean;
 }
 
 export default class StatsInnerList extends React.Component<StatsInnerListProps, {}> {
@@ -23,7 +24,7 @@ export default class StatsInnerList extends React.Component<StatsInnerListProps,
     let libraries = this.props.data[category];
     return libraries.map((l) => {
       return (
-        <li className="inner-stats-item" key={l.uuid}><p>{l.basic_info.name}{this.getGeographicInfo(l)}</p></li>
+        <li className="inner-stats-item" key={l.uuid}><p>{l.basic_info.name}{this.getMonth(l)}{this.getGeographicInfo(l)}</p></li>
       );
     });
   }
@@ -50,6 +51,14 @@ export default class StatsInnerList extends React.Component<StatsInnerListProps,
       return this.makeLi(category, allLengths);
     });
     return <ul className="stats-inner-list">{list}</ul>;
+  }
+
+  getMonth(library: LibraryData): string {
+    if (!this.props.showMonths) {
+      return "";
+    }
+    const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+    return ` (${months[new Date(library.basic_info.timestamp).getMonth()]})`;
   }
 
   getGeographicInfo(library: LibraryData): string {

--- a/src/components/StatsInnerList.tsx
+++ b/src/components/StatsInnerList.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { LibraryData } from "../interfaces";
-import { getPercentage } from "../utils/sharedFunctions";
+import { getPercentage, getMonth } from "../utils/sharedFunctions";
 
 export interface StatsInnerListProps {
   data: any;
@@ -58,7 +58,7 @@ export default class StatsInnerList extends React.Component<StatsInnerListProps,
       return "";
     }
     const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-    return ` (${months[new Date(library.basic_info.timestamp).getMonth()]})`;
+    return ` (${getMonth(library.basic_info.timestamp)})`;
   }
 
   getGeographicInfo(library: LibraryData): string {

--- a/src/components/StatsInnerList.tsx
+++ b/src/components/StatsInnerList.tsx
@@ -57,7 +57,6 @@ export default class StatsInnerList extends React.Component<StatsInnerListProps,
     if (!this.props.showMonths) {
       return "";
     }
-    const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
     return ` (${getMonth(library.basic_info.timestamp)})`;
   }
 

--- a/src/components/__tests__/StatsInnerList-test.tsx
+++ b/src/components/__tests__/StatsInnerList-test.tsx
@@ -92,6 +92,17 @@ describe("StatsInnerList", () => {
       expect(c.find("ul").hasClass("stats-category-list")).to.be.false;
     });
   });
+  it("optionally shows what month each library was added", () => {
+    wrapper.setProps({ stagesToShow: {"production": true, "testing": true, "cancelled": true }});
+    wrapper.setProps({ showMonths: true });
+    wrapper.find(".inner-stats-item").forEach(l => {
+      expect(new RegExp(/(November)/).test(l.text())).to.be.true;
+    });
+    wrapper.setProps({ showMonths: false });
+    wrapper.find(".inner-stats-item").forEach(l => {
+      expect(new RegExp(/(November)/).test(l.text())).to.be.false;
+    });
+  });
   it("optionally shows geographic information", () => {
     let nameLists = wrapper.find(".stats-category-list");
     expect(nameLists.at(0).text()).not.to.contain("(NY, ON, FL)");

--- a/src/components/__tests__/YearlyDataTab-test.tsx
+++ b/src/components/__tests__/YearlyDataTab-test.tsx
@@ -178,4 +178,35 @@ describe("YearlyDataTab", () => {
     expect(wrapper.state()["styled"]).to.be.false;
     expect(formattingButton.text()).to.equal("Restore Formatting");
   });
+
+  it("optionally displays the month each library was added", () => {
+    expect(wrapper.state().months).to.be.false;
+    expect(wrapper.find("button").length).to.equal(7);
+    wrapper.setState({ yearsToShow: {...wrapper.state().yearsToShow, ...{2019: true}}});
+    expect(wrapper.find("button").length).to.equal(8);
+    let monthsButton = wrapper.find("button").at(6);
+    expect(monthsButton.text()).to.equal("Show Months");
+    expect(wrapper.find(StatsInnerList).prop("showMonths")).to.be.false;
+    expect(wrapper.find(".inner-stats-item").at(0).text()).to.equal("Production Library 1");
+
+    monthsButton.simulate("click");
+
+    expect(wrapper.state().months).to.be.true;
+    expect(wrapper.find(StatsInnerList).prop("showMonths")).to.be.true;
+    expect(wrapper.find(".inner-stats-item").at(0).text()).to.equal("Production Library 1 (November)");
+    monthsButton = wrapper.find("button").at(6);
+    expect(monthsButton.text()).to.equal("Hide Months");
+
+    monthsButton.simulate("click");
+
+    expect(wrapper.state().months).to.be.false;
+    expect(wrapper.find(StatsInnerList).prop("showMonths")).to.be.false;
+    expect(wrapper.find(".inner-stats-item").at(0).text()).to.equal("Production Library 1");
+    monthsButton = wrapper.find("button").at(6);
+    expect(monthsButton.text()).to.equal("Show Months");
+
+    wrapper.setState({ yearsToShow: {...wrapper.state().yearsToShow, ...{2019: false}}});
+    expect(wrapper.find("button").length).to.equal(7);
+    expect(wrapper.find("button").at(6).text()).not.to.equal("Show Months");
+  });
 });

--- a/src/components/__tests__/YearlyDataTab-test.tsx
+++ b/src/components/__tests__/YearlyDataTab-test.tsx
@@ -185,7 +185,7 @@ describe("YearlyDataTab", () => {
     wrapper.setState({ yearsToShow: {...wrapper.state().yearsToShow, ...{2019: true}}});
     expect(wrapper.find("button").length).to.equal(8);
     let monthsButton = wrapper.find("button").at(6);
-    expect(monthsButton.text()).to.equal("Show Months");
+    expect(monthsButton.text()).to.equal("Show Month Added");
     expect(wrapper.find(StatsInnerList).prop("showMonths")).to.be.false;
     expect(wrapper.find(".inner-stats-item").at(0).text()).to.equal("Production Library 1");
 
@@ -195,7 +195,7 @@ describe("YearlyDataTab", () => {
     expect(wrapper.find(StatsInnerList).prop("showMonths")).to.be.true;
     expect(wrapper.find(".inner-stats-item").at(0).text()).to.equal("Production Library 1 (November)");
     monthsButton = wrapper.find("button").at(6);
-    expect(monthsButton.text()).to.equal("Hide Months");
+    expect(monthsButton.text()).to.equal("Hide Month Added");
 
     monthsButton.simulate("click");
 
@@ -203,10 +203,10 @@ describe("YearlyDataTab", () => {
     expect(wrapper.find(StatsInnerList).prop("showMonths")).to.be.false;
     expect(wrapper.find(".inner-stats-item").at(0).text()).to.equal("Production Library 1");
     monthsButton = wrapper.find("button").at(6);
-    expect(monthsButton.text()).to.equal("Show Months");
+    expect(monthsButton.text()).to.equal("Show Month Added");
 
     wrapper.setState({ yearsToShow: {...wrapper.state().yearsToShow, ...{2019: false}}});
     expect(wrapper.find("button").length).to.equal(7);
-    expect(wrapper.find("button").at(6).text()).not.to.equal("Show Months");
+    expect(wrapper.find("button").at(6).text()).not.to.equal("Show Month Added");
   });
 });

--- a/src/utils/sharedFunctions.ts
+++ b/src/utils/sharedFunctions.ts
@@ -16,3 +16,12 @@ export function getPercentage(x: number, outOf: number | string | Array<string |
   }
   return percentage;
 }
+
+export function getMonth(timestamp: string): string {
+  const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+  return `${months[new Date(timestamp).getMonth()]}`;
+}
+
+export function toggleState(attr: string, state) {
+  return {...state, ...{[attr]: !state[attr]}};
+}


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-2556  (Andrew is currently working on the metrics for which this information is relevant, so it would be good to get it out the door pretty quickly if possible.)

1) Sorts the list of libraries in the Yearly Data tab by month.
2) Optionally displays each library's month.

<img width="965" alt="Screen Shot 2020-02-10 at 3 32 52 PM" src="https://user-images.githubusercontent.com/42178216/74187471-a045a180-4c1a-11ea-8339-f2d75951e9bf.png">
