### PR TITLE
Additional email validation forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.4.8
+#### Added
+- Added display for and ability to validate the help email and copyright email, along with the contact email.
+
 ### v1.4.7
 #### Added
 - Added an option for displaying the month each library was added, in the Yearly Data tab.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.4.3",
+  "version": "1.4.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3176,28 +3176,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -3208,14 +3208,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -3226,42 +3226,42 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -3271,28 +3271,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -3302,14 +3302,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -3326,7 +3326,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -3341,14 +3341,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -3358,7 +3358,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -3368,7 +3368,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -3379,21 +3379,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -3403,14 +3403,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -3420,14 +3420,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -3438,7 +3438,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -3448,7 +3448,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -3458,14 +3458,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+          "resolved": false,
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -3477,7 +3477,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -3496,7 +3496,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -3507,14 +3507,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+          "resolved": false,
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -3525,7 +3525,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -3538,21 +3538,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -3562,21 +3562,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -3587,21 +3587,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -3614,7 +3614,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -3623,7 +3623,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -3639,7 +3639,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -3649,49 +3649,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -3703,7 +3703,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -3713,7 +3713,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -3723,14 +3723,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -3746,14 +3746,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -3763,14 +3763,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/EmailValidationForm.tsx
+++ b/src/components/EmailValidationForm.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
-import { Form, Button } from "library-simplified-reusable-components";
+import { Form } from "library-simplified-reusable-components";
 import { connect } from "react-redux";
 import ActionCreator from "../actions";
 import { FetchErrorData } from "opds-web-client/lib/interfaces";
 import { Store } from "redux";
 import { State } from "../reducers/index";
-import { LibraryData } from "../interfaces";
 import { CheckSoloIcon, XIcon } from "@nypl/dgx-svg-icons";
 
 export interface EmailValidationFormState {
@@ -37,7 +36,7 @@ export class EmailValidationForm extends React.Component<EmailValidationFormProp
     this.state = { validated: false };
   }
 
-  convert(email: string): string {
+  convertEmailTitle(email: string): string {
     return (email.includes("_") ? email.replace("_", " ") : email.replace(" ", "_"));
   }
 
@@ -64,8 +63,9 @@ export class EmailValidationForm extends React.Component<EmailValidationFormProp
   }
 
   render(): JSX.Element {
-    let emailString = this.convert(this.props.email);
+    let emailString = this.convertEmailTitle(this.props.email);
     let emailAddress = this.props.libraryInfo[this.props.email];
+    // libraryInfo has "contact_validated", "help_validated", and "copyright_validated" properties.
     let validated = this.props.libraryInfo[`${this.props.email.split("_")[0]}_validated`];
     let alreadyValidated = validated && (validated !== "Not validated");
     let successText = `Successfully validated ${emailAddress}`;

--- a/src/components/EmailValidationForm.tsx
+++ b/src/components/EmailValidationForm.tsx
@@ -79,7 +79,7 @@ export class EmailValidationForm extends React.Component<EmailValidationFormProp
         buttonContent={`Validate ${emailString}${alreadyValidated ? " again" : ""}`}
         buttonClass={`left-align top-align ${this.state.validated && "success"}`}
         disableButton={!emailAddress}
-        infoText={this.renderInfoText(emailString, emailAddress, validated, alreadyValidated)}
+        infoText={!this.state.validated &&  this.renderInfoText(emailString, emailAddress, validated, alreadyValidated)}
         errorText={this.props.error ? this.props.error.response : null}
         successText={this.state.validated ? successText : null}
       />

--- a/src/components/EmailValidationSection.tsx
+++ b/src/components/EmailValidationSection.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { Store } from "redux";
+import { State } from "../reducers/index";
+import { LibraryData } from "../interfaces";
+import EmailValidationForm from "./EmailValidationForm";
+
+export interface EmailValidationSectionProps {
+  library: LibraryData;
+  store: Store<State>;
+}
+
+export default class EmailValidationSection extends React.Component<EmailValidationSectionProps, {}> {
+  render(): JSX.Element {
+    let emailForms = ["contact", "help", "copyright"].map((x) =>
+      <li className="well">
+        <EmailValidationForm
+          store={this.props.store}
+          uuid={this.props.library.uuid}
+          email={`${x}_email`}
+          libraryInfo={this.props.library.urls_and_contact}
+        />
+      </li>
+    );
+    return (
+      <section className="validations">
+        <ul>{emailForms}</ul>
+      </section>
+    );
+  }
+}

--- a/src/components/EmailValidationSection.tsx
+++ b/src/components/EmailValidationSection.tsx
@@ -11,6 +11,9 @@ export interface EmailValidationSectionProps {
 
 export default class EmailValidationSection extends React.Component<EmailValidationSectionProps, {}> {
   render(): JSX.Element {
+    // The library has contact_email, help_email, and copyright_email properties.  Each of these corresponds
+    // to an email address which will need to be validated--either by the email recipient or by the user of
+    // this interface--before the library can be put into the production state.
     let emailForms = ["contact", "help", "copyright"].map((x) =>
       <li className="well">
         <EmailValidationForm

--- a/src/components/LibraryDetailPage.tsx
+++ b/src/components/LibraryDetailPage.tsx
@@ -7,7 +7,7 @@ import { State } from "../reducers/index";
 import LibraryDetailItem from "./LibraryDetailItem";
 import LibraryStageItem from "./LibraryStageItem";
 import { Form, Tabs } from "library-simplified-reusable-components";
-import EmailValidationForm from "./EmailValidationForm";
+import EmailValidationSection from "./EmailValidationSection";
 import PlsIDForm from "./PlsIDForm";
 
 export interface LibraryDetailPageDispatchProps {
@@ -114,10 +114,9 @@ export class LibraryDetailPage extends React.Component<LibraryDetailPageProps, L
       <div>
         { this.renderStages() }
         <hr />
-        <EmailValidationForm
+        <EmailValidationSection
           store={this.props.store}
           library={library}
-          fetchLibrary={this.props.fetchLibrary}
         />
         <hr />
         <PlsIDForm

--- a/src/components/__tests__/EmailValidationForm-test.tsx
+++ b/src/components/__tests__/EmailValidationForm-test.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import buildStore from "../../store";
 import { testLibrary1, modifyLibrary } from "./TestUtils";
 import { EmailValidationForm } from "../EmailValidationForm";
+import { Form } from "library-simplified-reusable-components";
 
 describe("EmailValidationForm", () => {
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
@@ -20,70 +21,72 @@ describe("EmailValidationForm", () => {
     wrapper = Enzyme.mount(
       <EmailValidationForm
         store={store}
-        library={library}
         validateEmail={validateEmail}
-        fetchLibrary={fetchLibrary}
+        uuid={library.uuid}
+        email="contact_email"
+        libraryInfo={library.urls_and_contact}
       />
     );
   });
 
-  it("renders a form with a title, a hidden value, and a button", () => {
-    expect(wrapper.find(".validation").hostNodes().length).to.equal(1);
+  it("renders a form with a title, a hidden input, and a button", () => {
+    let form = wrapper.find(Form);
 
-    let title = wrapper.find(".form-title");
-    expect(title.length).to.equal(1);
-    expect(title.text()).to.equal("Validation");
+    let title = form.find(".form-title");
+    expect(title.find("span").text()).to.equal("contact email: contact_email1");
+    expect(title.find("svg.x-icon").length).to.equal(1);
 
-    let hiddenInput = wrapper.find("[type='hidden']");
+    let hiddenInput = form.find("[type='hidden']");
     expect(hiddenInput.length).to.equal(1);
     expect(hiddenInput.prop("name")).to.equal("uuid");
     expect(hiddenInput.prop("value")).to.equal("UUID1");
 
-    let button = wrapper.find("button");
+    let button = form.find("button");
     expect(button.length).to.equal(1);
+    expect(button.text()).to.equal("Validate contact email");
   });
 
   it("displays the correct button content", () => {
-    let button = wrapper.find("button");
-    expect(button.text()).to.contain("Validate email address");
+    let button = wrapper.find("button").at(0);
+    expect(button.text()).to.contain("Validate contact email");
     expect(button.prop("disabled")).not.to.be.true;
 
-    let library = wrapper.prop("library");
-    wrapper.setProps({ library: modifyLibrary(library, {"validated": "validation time" })});
+    let libraryInfo = wrapper.prop("libraryInfo");
+    wrapper.setProps({ libraryInfo: {...libraryInfo, ...{"contact_validated": "validation time" }}});
     button = wrapper.find("button");
-    expect(button.text()).to.contain("Validate email address");
+    expect(button.text()).to.contain("Validate contact email again");
     expect(button.prop("disabled")).not.to.be.true;
 
-    wrapper.setProps({ library: modifyLibrary(library, {contact_email: null}) });
+    wrapper.setProps({ libraryInfo: {...libraryInfo, ...{"contact_email": null, "contact_validated": null }}});
     button = wrapper.find("button");
-    expect(button.text()).to.equal("No email address configured");
+    expect(button.text()).to.equal("Validate contact email");
     expect(button.prop("disabled")).to.be.true;
   });
 
-  it("displays the correct button icon", () => {
-    let icon = wrapper.find("button").find("svg");
-    expect(icon.length).to.equal(0);
+  it("displays the correct icon", () => {
+    let icon = wrapper.find("svg");
+    expect(icon.length).to.equal(1);
+    expect(icon.hasClass("x-icon")).to.be.true;
 
-    wrapper.setState({ sent: true });
+    wrapper.setState({ validated: true });
 
-    icon = wrapper.find("button").find("svg");
+    icon = wrapper.find("svg");
     expect(icon.length).to.equal(1);
     expect(icon.hasClass("check-solo-icon")).to.be.true;
   });
 
   it("displays an info message", () => {
     let info = wrapper.find(".alert-info");
-    expect(info.length).to.equal(0);
-
-    let library = wrapper.prop("library");
-    wrapper.setProps({ library: modifyLibrary(library, {"validated": "validation time" })});
-
-    info = wrapper.find(".alert-info");
     expect(info.length).to.equal(1);
-    expect(info.text()).to.equal("Already validated");
+    expect(info.text()).to.equal("Not validated");
+
+    let libraryInfo = wrapper.prop("libraryInfo");
+    wrapper.setProps({ libraryInfo: {...libraryInfo, ...{"contact_validated": "validation time" }}});
+    info = wrapper.find(".alert-info");
+    expect(info.text()).to.equal("Validated: validation time");
 
     // Hide the info message if there's a success message or an error message to display instead
-    wrapper.setState({ sent: true });
+    wrapper.setState({ validated: true });
     info = wrapper.find(".alert-info");
     expect(info.length).to.equal(0);
 
@@ -93,7 +96,7 @@ describe("EmailValidationForm", () => {
   });
 
   it("submits on click", async () => {
-    expect(wrapper.state()["sent"]).to.be.false;
+    expect(wrapper.state()["validated"]).to.be.false;
     wrapper.find("button").simulate("click");
     expect(validateEmail.callCount).to.equal(1);
     expect(validateEmail.args[0][0].get("uuid")).to.equal("UUID1");
@@ -103,14 +106,12 @@ describe("EmailValidationForm", () => {
     };
     await pause();
 
-    expect(fetchLibrary.callCount).to.equal(1);
-    expect(fetchLibrary.args[0][0]).to.equal("UUID1");
-    expect(wrapper.state()["sent"]).to.be.true;
+    expect(wrapper.state()["validated"]).to.be.true;
   });
 
-  it("does not set 'sent' to true if there is an error", async () => {
-    expect(wrapper.state()["sent"]).to.be.false;
-    wrapper.find("button").simulate("click");
+  it("does not set 'validated' to true if there is an error", async () => {
+    expect(wrapper.state()["validated"]).to.be.false;
+    wrapper.find("button").at(0).simulate("click");
 
 
     const pause = (): Promise<void> => {
@@ -119,19 +120,19 @@ describe("EmailValidationForm", () => {
       });
     };
 
-    expect(wrapper.state()["sent"]).to.be.false;
-    expect(wrapper.find("button").find("svg").length).to.equal(0);
+    expect(wrapper.state()["validated"]).to.be.false;
+    expect(wrapper.find("button").at(0).find("svg").length).to.equal(0);
   });
 
   it("displays a success message", () => {
     let successMessage = wrapper.find(".alert-success");
     expect(successMessage.length).to.equal(0);
 
-    wrapper.setState({ sent: true });
+    wrapper.setState({ validated: true });
 
-    successMessage = wrapper.find(".alert-success");
+    successMessage = wrapper.find(".alert-success").at(0);
     expect(successMessage.length).to.equal(1);
-    expect(successMessage.text()).to.equal("Successfully validated email1");
+    expect(successMessage.text()).to.equal("Successfully validated contact_email1");
   });
 
   it("displays an error message", () => {
@@ -140,7 +141,7 @@ describe("EmailValidationForm", () => {
 
     wrapper.setProps({ error: { response: "Failed to validate email address" } });
 
-    errorMessage = wrapper.find(".alert-danger");
+    errorMessage = wrapper.find(".alert-danger").at(0);
     expect(errorMessage.length).to.equal(1);
     expect(errorMessage.text()).to.equal("Failed to validate email address");
   });

--- a/src/components/__tests__/EmailValidationSection-test.tsx
+++ b/src/components/__tests__/EmailValidationSection-test.tsx
@@ -1,0 +1,44 @@
+import { expect } from "chai";
+import * as Sinon from "sinon";
+import * as Enzyme from "enzyme";
+import * as React from "react";
+import buildStore from "../../store";
+import { testLibrary1, modifyLibrary } from "./TestUtils";
+import EmailValidationSection from "../EmailValidationSection";
+import { EmailValidationForm } from "../EmailValidationForm";
+import { Form } from "library-simplified-reusable-components";
+
+describe("EmailValidationSection", () => {
+  let store;
+  let wrapper;
+  beforeEach(() => {
+    store = buildStore();
+    wrapper = Enzyme.mount(
+      <EmailValidationSection
+        library={testLibrary1}
+        store={store}
+      />
+    );
+  });
+  it("renders a section with three forms", () => {
+    let section = wrapper.find("section");
+    expect(section.length).to.equal(1);
+    expect(section.hasClass("validations")).to.be.true;
+    expect(section.find(EmailValidationForm).length).to.equal(3);
+  });
+  it("passes the correct props to each form", () => {
+    let [contactForm, helpForm, copyrightForm] = wrapper.find(EmailValidationForm).map(x => x);
+
+    expect(contactForm.prop("uuid")).to.equal(testLibrary1.uuid);
+    expect(contactForm.prop("email")).to.equal("contact_email");
+    expect(contactForm.prop("libraryInfo")).to.eql(testLibrary1.urls_and_contact);
+
+    expect(helpForm.prop("uuid")).to.equal(testLibrary1.uuid);
+    expect(helpForm.prop("email")).to.equal("help_email");
+    expect(helpForm.prop("libraryInfo")).to.eql(testLibrary1.urls_and_contact);
+
+    expect(copyrightForm.prop("uuid")).to.equal(testLibrary1.uuid);
+    expect(copyrightForm.prop("email")).to.equal("copyright_email");
+    expect(copyrightForm.prop("libraryInfo")).to.eql(testLibrary1.urls_and_contact);
+  });
+});

--- a/src/components/__tests__/LibraryDetailPage-test.tsx
+++ b/src/components/__tests__/LibraryDetailPage-test.tsx
@@ -57,12 +57,14 @@ describe("LibraryDetailPage", () => {
 
     expect(urlsContactCall.args[0]).to.equal(library.urls_and_contact);
     expect(urlsContactCall.returnValue.type).to.equal("ul");
-    expect(urlsContactCall.returnValue.props.children.length).to.equal(4);
-    let [authentication_url, contact_email, opds_url, web_url] = urlsContactCall.returnValue.props.children;
+    expect(urlsContactCall.returnValue.props.children.length).to.equal(6);
+    let [authentication_url, contact_email, help_email, copyright_email, opds_url, web_url] = urlsContactCall.returnValue.props.children;
     expect(authentication_url.props.label).to.equal("authentication_url");
     expect(authentication_url.props.value).to.equal("auth1");
     expect(contact_email.props.label).to.equal("contact_email");
-    expect(contact_email.props.value).to.equal("email1");
+    expect(contact_email.props.value).to.equal("contact_email1");
+    expect(help_email.props.label).to.equal("help_email");
+    expect(help_email.props.value).to.equal("help_email1");
     expect(opds_url.props.label).to.equal("opds_url");
     expect(opds_url.props.value).to.equal("opds1");
     expect(web_url.props.label).to.equal("web_url");
@@ -86,7 +88,7 @@ describe("LibraryDetailPage", () => {
     expect(basicInfoItems.length).to.equal(4);
 
     let contactUrlItems = list.at(1).find("li");
-    expect(contactUrlItems.length).to.equal(4);
+    expect(contactUrlItems.length).to.equal(6);
 
     let allItems = Object.assign(basicInfoItems, contactUrlItems);
     let libraryData = Object.assign(library.basic_info, library.urls_and_contact);
@@ -170,13 +172,15 @@ describe("LibraryDetailPage", () => {
     expect(updateColor.args[0][0][1]).to.equal("production");
   });
 
-  it("should display the validation form", () => {
-    let validationForm = wrapper.find("form").at(1);
-    expect(validationForm.find(".form-title").text()).to.equal("Validation");
+  it("should display the validation forms", () => {
+    let validationSection = wrapper.find(".validations");
+    expect(validationSection.length).to.equal(1);
+    let validationForms = validationSection.find("form");
+    expect(validationForms.length).to.equal(3);
   });
 
   it("should display the PLS ID form", () => {
-    let plsIDForm = wrapper.find("form").at(2);
+    let plsIDForm = wrapper.find("form").at(4);
     expect(plsIDForm.find(".form-title").text()).to.equal("Public Libraries Survey ID");
   });
 

--- a/src/components/__tests__/TestUtils.ts
+++ b/src/components/__tests__/TestUtils.ts
@@ -14,7 +14,9 @@ export const testLibrary1: LibraryData = {
   },
   urls_and_contact: {
     "authentication_url": "auth1",
-    "contact_email": "email1",
+    "contact_email": "contact_email1",
+    "help_email": "help_email1",
+    "copyright_email": "copyright_email1",
     "opds_url": "opds1",
     "web_url": "web1"
   },
@@ -38,7 +40,9 @@ export const testLibrary2: LibraryData = {
   },
   urls_and_contact: {
     "authentication_url": "auth2",
-    "contact_email": "email2",
+    "contact_email": "contact_email2",
+    "help_email": "help_email2",
+    "copyright_email": "copyright_email2",
     "opds_url": "opds2",
     "web_url": "web2"
   },
@@ -119,9 +123,9 @@ describe("TestUtils", () => {
 
   it("takes an optional category argument", () => {
     let baseLibrary = testLibrary1;
-    expect(baseLibrary.urls_and_contact.validated).to.be.undefined;
-    let updatedLibrary = modifyLibrary(baseLibrary, {validated: "VALIDATED!"}, "urls_and_contact");
-    expect(updatedLibrary.urls_and_contact.validated).to.equal("VALIDATED!");
+    expect(baseLibrary.urls_and_contact.contact_validated).to.be.undefined;
+    let updatedLibrary = modifyLibrary(baseLibrary, {contact_validated: "VALIDATED!"}, "urls_and_contact");
+    expect(updatedLibrary.urls_and_contact.contact_validated).to.equal("VALIDATED!");
   });
 
   it("modifies the UUID", () => {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,7 +17,11 @@ export interface LibraryData {
     contact_email: string,
     opds_url: string,
     web_url: string,
-    validated?: string
+    contact_validated?: string,
+    help_email: string,
+    help_validated?: string,
+    copyright_email?: string,
+    copyright_validated?: string
   };
   areas: {
     focus: string[],

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -7,6 +7,7 @@
 @import "global";
 
 @import "detail_page";
+@import "email_form";
 @import "filter";
 @import "icon";
 @import "libraries_page";

--- a/src/stylesheets/email_form.scss
+++ b/src/stylesheets/email_form.scss
@@ -1,0 +1,29 @@
+.validations {
+  border: 1px solid $blue;
+  width: 55vw;
+  margin-left: 20px;
+  ul {
+    padding: 24px;
+    list-style: none;
+    li {
+      display: block;
+      margin-bottom: 12px;
+      padding: 0;
+      form {
+        width: 100%;
+        margin: 0;
+        .form-title {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          .x-icon {
+            fill: $red;
+          }
+          .check-solo-icon {
+            fill: $green-bright;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Goes with https://github.com/NYPL-Simplified/library_registry/tree/validate-emails-to-register (which will have its own PR as soon as I'm done with the tests).  Resolves https://jira.nypl.org/browse/SIMPLY-2605

<img width="784" alt="Screen Shot 2020-03-05 at 4 40 40 PM" src="https://user-images.githubusercontent.com/42178216/76028229-22ff0b00-5f00-11ea-85f8-70590cb1e742.png">
<img width="794" alt="Screen Shot 2020-03-05 at 4 40 49 PM" src="https://user-images.githubusercontent.com/42178216/76028230-25616500-5f00-11ea-8200-13e705bb43f0.png">
<img width="815" alt="Screen Shot 2020-03-05 at 4 41 33 PM" src="https://user-images.githubusercontent.com/42178216/76028246-301bfa00-5f00-11ea-9b19-3be6d8e05179.png">
<img width="599" alt="Screen Shot 2020-03-09 at 4 59 42 PM" src="https://user-images.githubusercontent.com/42178216/76257107-6ec6f280-6227-11ea-93da-d7358f584493.png">
