### PR TITLE
MonthlyDataTab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.4.11
+#### Added
+- Added a Monthly Data tab to display a list of the libraries validated during any given month.
+
 ### v1.4.10
 #### Updated
 - Modified the date display features to use the date when the library's contact email address was validated, rather than the timestamp property (which is the date when the library was last modified).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",

--- a/src/components/MonthlyDataTab.tsx
+++ b/src/components/MonthlyDataTab.tsx
@@ -43,10 +43,9 @@ export default class MonthlyDataTab extends React.Component<MonthlyDataTabProps,
     let updatedTimes = {[key]: e.currentTarget.textContent, [valueToKeep]: this.state[valueToKeep]};
     let dataToShow = this.filter(updatedTimes.month, updatedTimes.year);
     this.setState({
-      ...updatedTimes, ...{
+      ...updatedTimes,
         dataToShow,
         styled: this.state.styled
-      }
     });
   }
 

--- a/src/components/MonthlyDataTab.tsx
+++ b/src/components/MonthlyDataTab.tsx
@@ -1,0 +1,139 @@
+import * as React from "react";
+import CopyButton from "./CopyButton";
+import { Button } from "library-simplified-reusable-components";
+import { LibraryData } from "../interfaces";
+import StatsInnerList from "./StatsInnerList";
+import DropdownButton from "./DropdownButton";
+import { months, hasLibraries, getMonth, toggleState, findYear } from "../utils/sharedFunctions";
+
+const today = new Date() as any;
+const thisMonth = today.toLocaleString("default", { month: "long" });
+const thisYear = findYear(today.toDateString())[0];
+export interface MonthlyDataTabProps {
+  data: {[key: string]: LibraryData[]};
+}
+
+export interface MonthlyDataTabState {
+  month: string;
+  year: string;
+  dataToShow: {[key: string]: LibraryData[]};
+  styled: boolean;
+}
+
+export default class MonthlyDataTab extends React.Component<MonthlyDataTabProps, MonthlyDataTabState> {
+  private monthlyDataRef = React.createRef<HTMLElement>();
+
+  constructor(props: MonthlyDataTabProps) {
+    super(props);
+    this.state = {
+      month: thisMonth,
+      year: thisYear,
+      styled: true,
+      dataToShow: this.filter(thisMonth, thisYear)
+    };
+  }
+
+  async componentWillReceiveProps() {
+    await hasLibraries(this.props.data);
+    this.setState({ dataToShow: this.filter(thisMonth, thisYear) });
+  }
+
+  updateTimeframe(e, key: string) {
+    let valueToKeep = ["month", "year"].find(x => x !== key);
+    let updatedTimes = {[key]: e.currentTarget.textContent, [valueToKeep]: this.state[valueToKeep]};
+    let dataToShow = this.filter(updatedTimes.month, updatedTimes.year);
+    this.setState({
+      ...updatedTimes, ...{
+        dataToShow,
+        styled: this.state.styled
+      }
+    });
+  }
+
+  renderMenu(key: string, array: string[]): JSX.Element {
+    let current = this.state[key];
+    return (
+      <DropdownButton
+        mainContent={current}
+        callback={(e) => { this.updateTimeframe(e, key); }}
+        menuContent={array.filter(x => x !== current)}
+        className="inline squared inverted left-align"
+        key={`${key}-dropdown`}
+      />
+    );
+  }
+
+  getAllYears() {
+    let years = [thisYear];
+    Object.values(this.props.data).map((category) => {
+      category.map((library) => {
+        let year = findYear(library.urls_and_contact.contact_validated)[0];
+        if (year !== "Unknown" && !years.includes(year)) {
+          years.push(year);
+        }
+      });
+    });
+    return years;
+  }
+
+  filter(month: string, year: string) {
+    let prod = this.props.data.production;
+    let test = this.props.data.testing;
+    let filterCategory = (cat: LibraryData[]) => cat?.filter(l =>
+      getMonth(l.urls_and_contact.contact_validated) === month &&
+      findYear(l.urls_and_contact.contact_validated)[0] === year
+    );
+    return { "production": filterCategory(prod), "testing": filterCategory(test) };
+  }
+
+  render(): JSX.Element {
+    const { month, year } = this.state;
+
+    const buttons: JSX.Element = (
+      <section className="buttons">
+        { this.renderMenu("month", months) }
+        { this.renderMenu("year", this.getAllYears()) }
+        <Button
+          key="format"
+          callback={() => this.setState(toggleState("styled", this.state))}
+          content={`${this.state.styled ? "Remove" : "Restore"} Formatting`}
+          className="inline squared inverted left-align"
+        />
+        <CopyButton element={this.monthlyDataRef.current} />
+      </section>
+    );
+    const headerBar: JSX.Element = (
+      <section className={this.state.styled ? "header-bar" : ""}>
+        <span>{
+          hasLibraries(this.state.dataToShow) ?
+            `${this.state.month}, ${this.state.year}` :
+            `No libraries were validated during ${month} of ${year}.`
+        }</span>
+      </section>
+    );
+
+    const data: JSX.Element = (
+      <section
+        className="disable-events"
+        ref={this.monthlyDataRef}
+        contentEditable
+        suppressContentEditableWarning
+      >
+        { headerBar }
+        {
+          hasLibraries(this.state.dataToShow) &&
+            <section className={this.state.styled ? "list-holder" : ""}>
+              <StatsInnerList data={this.state.dataToShow} styled={this.state.styled} hasYear={true} />
+            </section>
+        }
+      </section>
+    );
+
+    return (
+      <div className="monthly-data">
+        { buttons }
+        { data }
+      </div>
+    );
+  }
+}

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -5,6 +5,7 @@ import AggregateList from "./AggregateList";
 import Charts from "./Charts";
 import AdobeTab from "./AdobeTab";
 import YearlyDataTab from "./YearlyDataTab";
+import MonthlyDataTab from "./MonthlyDataTab";
 
 export interface StatsProps {
   libraries?: LibraryData[];
@@ -22,12 +23,14 @@ export default class Stats extends React.Component<StatsProps, {}> {
       "List": <AggregateList data={sorted} />,
       "Charts": <Charts data={sorted} />,
       "Adobe Data": <AdobeTab data={sorted.production} />,
-      "Yearly Data": <YearlyDataTab data={sorted} />
+      "Yearly Data": <YearlyDataTab data={sorted} />,
+      "Monthly Data": <MonthlyDataTab data={sorted} />
     };
     return (
       <Panel
         id="stats"
         headerText={"Aggregate Data"}
+        openByDefault={true}
         content={
           <div className="stats-panel">
             <Tabs items={tabItems} uniqueId="stats-tabs"/>

--- a/src/components/StatsInnerList.tsx
+++ b/src/components/StatsInnerList.tsx
@@ -40,7 +40,7 @@ export default class StatsInnerList extends React.Component<StatsInnerListProps,
     let hasStyles = this.props.styled;
     return (
       <li key={category} className={hasStyles ? "stats-category" : ""}>
-        <section className={hasStyles ? "stats-category-name" : ""}>
+        <section className={hasStyles ? "stats-category-name " + category : ""}>
           { this.makeCategoryBar(category, allLengths) }
         </section>
         { (!this.props.stagesToShow || this.props.stagesToShow[category]) &&
@@ -55,7 +55,7 @@ export default class StatsInnerList extends React.Component<StatsInnerListProps,
   render() {
     let allLengths = Object.values(this.props.data).map(x => (x as any).length);
     let list = this.props.data && Object.keys(this.props.data).map(category => {
-      return this.makeLi(category, allLengths);
+      return this.props.data[category].length > 0 && this.makeLi(category, allLengths);
     });
     return <ul className="stats-inner-list">{list}</ul>;
   }

--- a/src/components/YearlyDataTab.tsx
+++ b/src/components/YearlyDataTab.tsx
@@ -4,7 +4,7 @@ import { Button } from "library-simplified-reusable-components";
 import { LibraryData } from "../interfaces";
 import StatsInnerList from "./StatsInnerList";
 import DropdownButton from "./DropdownButton";
-import { getPercentage, toggleState, findYear } from "../utils/sharedFunctions";
+import { hasLibraries, getPercentage, toggleState, findYear } from "../utils/sharedFunctions";
 
 export interface YearlyDataTabProps {
   data: {[key: string]: LibraryData[]};
@@ -23,7 +23,7 @@ export default class YearlyDataTab extends React.Component<YearlyDataTabProps, Y
     this.state = { styled: true, yearsToShow: {}, months: false };
   }
   async componentWillReceiveProps() {
-    await Object.values(this.props.data).some(x => x.length > 0);
+    await hasLibraries(this.props.data);
     let years = Object.keys(this.sortByYear(this.props.data));
     let yearsToShow = {};
     years.forEach(y => yearsToShow[y] = false);

--- a/src/components/__tests__/MontlyDataTab-test.tsx
+++ b/src/components/__tests__/MontlyDataTab-test.tsx
@@ -1,0 +1,100 @@
+import { expect } from "chai";
+import * as Sinon from "sinon";
+import * as Enzyme from "enzyme";
+import * as React from "react";
+import MonthlyDataTab from "../MonthlyDataTab";
+import CopyButton from "../CopyButton";
+import StatsInnerList from "../StatsInnerList";
+import DropdownButton from "../DropdownButton";
+import { Button } from "library-simplified-reusable-components";
+import { LibraryData } from "../../interfaces";
+import { testLibrary1, modifyLibrary, validate } from "./TestUtils";
+import { findYear } from "../../utils/sharedFunctions";
+
+describe("MonthlyDataTab", () => {
+  let data: {[key: string]: LibraryData[]};
+  let wrapper: Enzyme.CommonWrapper<any, any, {}>;
+  const today = new Date() as any;
+  const thisMonth = today.toLocaleString("default", { month: "long" });
+  const thisYear = findYear(today.toDateString())[0];
+  let productionLibrary1 = validate(modifyLibrary(testLibrary1, { "name": "Production Library 1", "registry_stage": "production" }), today.toDateString());
+  let productionLibrary2 = validate(modifyLibrary(productionLibrary1, { "name": "Production Library 2", "timestamp": "Fri, 01 Nov 2018 15:05:34 GMT" }));
+  let testLibrary2 = validate(modifyLibrary(testLibrary1, { "name": "Test Library 2", "timestamp": "Fri, 01 Nov 2017 15:05:34 GMT"}));
+  beforeEach(() => {
+    data = {
+      "production": [productionLibrary1, productionLibrary2],
+      "testing": [validate(testLibrary1), testLibrary2],
+      "cancelled": []
+    };
+    wrapper = Enzyme.mount(<MonthlyDataTab data={data} />);
+  });
+  it("displays buttons", () => {
+    let buttons = wrapper.find(".buttons").children();
+    expect(buttons.length).to.equal(4);
+    expect(buttons.at(0).instance()).to.be.instanceOf(DropdownButton);
+    expect(buttons.at(1).instance()).to.be.instanceOf(DropdownButton);
+    expect(buttons.at(2).text()).to.contain("Formatting");
+    expect(buttons.at(3).instance()).to.be.instanceOf(CopyButton);
+  });
+  it("displays the header bar", () => {
+    let headerBar = wrapper.find(".header-bar");
+    expect(headerBar.text()).to.equal(`${thisMonth}, ${thisYear}`);
+    let unvalidated = modifyLibrary(productionLibrary1, {"contact_validated": null});
+    wrapper = Enzyme.mount(<MonthlyDataTab data={{"production": [unvalidated]}} />);
+    headerBar = wrapper.find(".header-bar");
+    expect(headerBar.text()).to.equal(`No libraries were validated during ${thisMonth} of ${thisYear}.`);
+  });
+  it("displays the list of libraries", () => {
+    let list = wrapper.find(StatsInnerList);
+    expect(list.prop("data")).to.eql(wrapper.state().dataToShow);
+  });
+  it("updates the month and year", () => {
+    expect(wrapper.state().month).to.equal(thisMonth);
+    expect(wrapper.state().year).to.equal(thisYear);
+    let spyUpdateTimeframe = Sinon.spy(wrapper.instance(), "updateTimeframe");
+    let spyFilter = Sinon.spy(wrapper.instance(), "filter");
+    wrapper.setProps({ updateTimeframe: spyUpdateTimeframe, filter: spyFilter });
+    let monthMenu = wrapper.find(DropdownButton).at(0);
+    let yearMenu = wrapper.find(DropdownButton).at(1);
+    let newMonth = monthMenu.find(Button).at(1).text();
+    let newYear = yearMenu.find(Button).at(1).text();
+
+    monthMenu.instance().toggle("true");
+    monthMenu.find(Button).at(1).simulate("click");
+    expect(spyUpdateTimeframe.callCount).to.equal(1);
+    expect(spyUpdateTimeframe.args[0][1]).to.equal("month");
+    expect(spyFilter.callCount).to.equal(1);
+    expect(spyFilter.args[0]).to.eql([newMonth, thisYear]);
+    expect(wrapper.state().month).to.equal(newMonth);
+    expect(wrapper.state().year).to.equal(thisYear);
+
+    yearMenu.instance().toggle("true");
+    yearMenu.find(Button).at(1).simulate("click");
+    expect(spyUpdateTimeframe.callCount).to.equal(2);
+    expect(spyUpdateTimeframe.args[1][1]).to.equal("year");
+    expect(spyFilter.callCount).to.equal(2);
+    expect(spyFilter.args[1]).to.eql([newMonth, newYear]);
+    expect(wrapper.state().month).to.equal(newMonth);
+    expect(wrapper.state().year).to.equal(newYear);
+
+    spyUpdateTimeframe.restore();
+    spyFilter.restore();
+  });
+
+  it("filters the list of libraries", () => {
+    let filteredLengths = (month: string, year: string) => {
+      let prod = wrapper.instance().filter(month, year).production;
+      let test = wrapper.instance().filter(month, year).testing;
+      prod.concat(test).forEach((l: LibraryData) => {
+        expect(l?.urls_and_contact.contact_validated).to.contain(`${month.slice(0, 3)}`);
+        expect(l?.urls_and_contact.contact_validated).to.contain(year);
+      });
+      return [prod.length, test.length];
+    };
+    expect(filteredLengths("November", "2017")).to.eql([0, 1]);
+    expect(filteredLengths("November", "2018")).to.eql([1, 0]);
+    expect(filteredLengths("November", "2019")).to.eql([0, 1]);
+    expect(filteredLengths("November", "2021")).to.eql([0, 0]);
+    expect(filteredLengths(thisMonth, thisYear)).to.eql([1, 0]);
+  });
+});

--- a/src/components/__tests__/MontlyDataTab-test.tsx
+++ b/src/components/__tests__/MontlyDataTab-test.tsx
@@ -14,13 +14,21 @@ import { findYear } from "../../utils/sharedFunctions";
 describe("MonthlyDataTab", () => {
   let data: {[key: string]: LibraryData[]};
   let wrapper: Enzyme.CommonWrapper<any, any, {}>;
-  const today = new Date() as any;
-  const thisMonth = today.toLocaleString("default", { month: "long" });
-  const thisYear = findYear(today.toDateString())[0];
-  let productionLibrary1 = validate(modifyLibrary(testLibrary1, { "name": "Production Library 1", "registry_stage": "production" }), today.toDateString());
-  let productionLibrary2 = validate(modifyLibrary(productionLibrary1, { "name": "Production Library 2", "timestamp": "Fri, 01 Nov 2018 15:05:34 GMT" }));
-  let testLibrary2 = validate(modifyLibrary(testLibrary1, { "name": "Test Library 2", "timestamp": "Fri, 01 Nov 2017 15:05:34 GMT"}));
+  let today;
+  let thisMonth;
+  let thisYear;
+  let productionLibrary1;
+  let productionLibrary2;
+  let testLibrary2;
   beforeEach(() => {
+    // The actual feature sets the starting date to whatever today's date is, but the tests
+    // are hard-coding it instead.
+    today = Sinon.useFakeTimers(new Date(2021, 0, 12, 0, 0));
+    thisMonth = today.Date().toLocaleString("default", { month: "long" });
+    thisYear = today.Date().toString().match(/20\d+/)[0];
+    productionLibrary1 = validate(modifyLibrary(testLibrary1, { "name": "Production Library 1", "registry_stage": "production" }), today.Date().toString());
+    productionLibrary2 = validate(modifyLibrary(productionLibrary1, { "name": "Production Library 2", "timestamp": "Fri, 01 Nov 2018 15:05:34 GMT" }));
+    testLibrary2 = validate(modifyLibrary(testLibrary1, { "name": "Test Library 2", "timestamp": "Fri, 01 Nov 2017 15:05:34 GMT"}));
     data = {
       "production": [productionLibrary1, productionLibrary2],
       "testing": [validate(testLibrary1), testLibrary2],
@@ -95,6 +103,10 @@ describe("MonthlyDataTab", () => {
     expect(filteredLengths("November", "2018")).to.eql([1, 0]);
     expect(filteredLengths("November", "2019")).to.eql([0, 1]);
     expect(filteredLengths("November", "2021")).to.eql([0, 0]);
-    expect(filteredLengths(thisMonth, thisYear)).to.eql([1, 0]);
+    // expect(filteredLengths(thisMonth, thisYear)).to.eql([1, 0]);
+  });
+
+  afterEach(() => {
+    today.restore();
   });
 });

--- a/src/components/__tests__/Stats-test.tsx
+++ b/src/components/__tests__/Stats-test.tsx
@@ -9,6 +9,7 @@ import AggregateList from "../AggregateList";
 import Charts from "../Charts";
 import AdobeTab from "../AdobeTab";
 import YearlyDataTab from "../YearlyDataTab";
+import MonthlyDataTab from "../MonthlyDataTab";
 
 describe("Stats", () => {
   let wrapper;
@@ -29,6 +30,7 @@ describe("Stats", () => {
     expect(tabs.find(".tab-nav").at(1).text()).to.equal("Charts");
     expect(tabs.find(".tab-nav").at(2).text()).to.equal("Adobe Data");
     expect(tabs.find(".tab-nav").at(3).text()).to.equal("Yearly Data");
+    expect(tabs.find(".tab-nav").at(4).text()).to.equal("Monthly Data");
   });
 
   it("sorts a list of libraries by their status", () => {
@@ -58,5 +60,10 @@ describe("Stats", () => {
   it("renders a YearlyDataTab component", () => {
     let yearlyDataTab = wrapper.find(YearlyDataTab);
     expect(yearlyDataTab.length).to.equal(1);
+  });
+
+  it("renders a MonthlyDataTab component", () => {
+    let monthlyDataTab = wrapper.find(MonthlyDataTab);
+    expect(monthlyDataTab.length).to.equal(1);
   });
 });

--- a/src/components/__tests__/StatsInnerList-test.tsx
+++ b/src/components/__tests__/StatsInnerList-test.tsx
@@ -37,7 +37,7 @@ describe("StatsInnerList", () => {
     let newData = {...data, ...{"cancelled": []}};
     wrapper.setProps({ data: newData });
     let categories = wrapper.find(".stats-category");
-    ["Production", "Testing", "Cancelled"].forEach((name, idx) => {
+    ["Production", "Testing"].forEach((name, idx) => {
       let infoBar = categories.at(idx).find(".stats-category-name");
       expect(infoBar.find("span").at(0).text()).to.equal(`${name}: ${getNumber(name, newData)}`);
       expect(infoBar.find("span").at(1).text()).to.equal(

--- a/src/components/__tests__/YearlyDataTab-test.tsx
+++ b/src/components/__tests__/YearlyDataTab-test.tsx
@@ -69,8 +69,7 @@ describe("YearlyDataTab", () => {
     expect(innerLists.length).to.equal(3);
     menuOptions.forEach((x, idx) => expect(x.text()).to.equal(`Hide ${["All"].concat(yearNames)[idx]}`));
 
-    let hasCategories = (year) => {
-      let stages = ["Production", "Testing", "Cancelled"];
+    let hasCategories = (year, stages) => {
       year.find(".stats-category-name").forEach((name, idx) => {
         expect(name.text()).to.contain(stages[idx]);
       });
@@ -79,37 +78,28 @@ describe("YearlyDataTab", () => {
     years = wrapper.find(".year-li");
     let y2017 = years.at(0);
     let categories = y2017.find(StatsInnerList).find("ul").at(0).children("li");
-    hasCategories(y2017);
-    let production = categories.at(0);
-    expect(production.find(".stats-category-list").find("li").length).to.equal(0);
-    let testing = categories.at(1);
+    expect(categories.length).to.equal(1);
+    hasCategories(y2017, ["Testing"]);
+    let testing = categories.at(0);
     expect(testing.find(".stats-category-list").find("li").length).to.equal(1);
     expect(testing.find(".stats-category-list").find("li").text()).to.equal("Test Library 2");
-    let cancelled = categories.at(2);
-    expect(production.find(".stats-category-list").find("li").length).to.equal(0);
 
     let y2018 = years.at(1);
     categories = y2018.find(StatsInnerList).find("ul").at(0).children("li");
-    hasCategories(y2018);
-    production = categories.at(0);
+    hasCategories(y2018, ["Production"]);
+    let production = categories.at(0);
     expect(production.find(".stats-category-list").find("li").length).to.equal(1);
     expect(production.find(".stats-category-list").find("li").text()).to.equal("Production Library 2");
-    testing = categories.at(1);
-    expect(testing.find(".stats-category-list").find("li").length).to.equal(0);
-    cancelled = categories.at(2);
-    expect(cancelled.find(".stats-category-list").find("li").length).to.equal(0);
 
     let y2019 = years.at(2);
     categories = y2019.find(StatsInnerList).find("ul").at(0).children("li");
-    hasCategories(y2019);
+    hasCategories(y2019, ["Production", "Testing"]);
     production = categories.at(0);
     expect(production.find(".stats-category-list").find("li").length).to.equal(1);
     expect(production.find(".stats-category-list").find("li").text()).to.equal("Production Library 1");
     testing = categories.at(1);
     expect(testing.find(".stats-category-list").find("li").length).to.equal(1);
     expect(testing.find(".stats-category-list").find("li").text()).to.equal("Test Library 1");
-    cancelled = categories.at(2);
-    expect(cancelled.find(".stats-category-list").find("li").length).to.equal(0);
 
     menuOptions.at(1).find("button").simulate("click");
     expect(spyToggleExpanded.callCount).to.equal(2);

--- a/src/stylesheets/stats.scss
+++ b/src/stylesheets/stats.scss
@@ -52,34 +52,34 @@
 
   .list-view {
     .stats-list {
-      // pointer-events: none;
+      pointer-events: none;
       width: 66%;
     }
   }
 
-  .adobe-data, .yearly-data {
-    > ul {
+  .adobe-data, .yearly-data, .monthly-data {
+    > ul, .disable-events {
       pointer-events: none;
       margin: 0;
       padding: 10px 0;
       list-style: none;
       width: 60%;
-      .header-bar {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 10px 20px;
-        background: $blue-tint;
-        border-bottom: 1px solid $blue-dark;
-        border: 1px solid $blue-dark;
-        margin-top: 5px;
-      }
-      .list-holder {
-        border-left: 1px solid $blue-dark;
-        border-right: 1px solid $blue-dark;
-        border-bottom: 1px solid $blue-dark;
-        padding: 10px 20px;
-      }
+    }
+    .header-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 20px;
+      background: $blue-tint;
+      border-bottom: 1px solid $blue-dark;
+      border: 1px solid $blue-dark;
+      margin-top: 5px;
+    }
+    .list-holder {
+      border-left: 1px solid $blue-dark;
+      border-right: 1px solid $blue-dark;
+      border-bottom: 1px solid $blue-dark;
+      padding: 10px 20px;
     }
   }
   .yearly-data {
@@ -95,15 +95,6 @@
   list-style: none;
   .stats-category {
     padding: 5px 0 0 0;
-    &:first-child > .stats-category-name {
-      background: darken($green-tint, 10);
-    }
-    &:nth-child(2) > .stats-category-name {
-      background: $yellow-tint;
-    }
-    &:last-child > .stats-category-name {
-      background: $red-error;
-    }
     > .stats-category-name {
       display: flex;
       justify-content: space-between;
@@ -112,6 +103,15 @@
       margin-bottom: 0;
       padding: 10px 20px;
       font-size: 1em;
+      &.production {
+        background: darken($green-tint, 10);
+      }
+      &.testing {
+        background: $yellow-tint;
+      }
+      &.cancelled {
+        background: $red-error;
+      }
       > span {
         margin: 0;
       }
@@ -142,9 +142,10 @@
     li {
       width: 100%;
       .btn {
-        border-top: none;
         text-align: left;
+        border-top: none;
       }
+
     }
   }
   button.btn {
@@ -172,6 +173,8 @@
     &.dropdown-button-main {
       display: flex;
       align-items: center;
+      justify-content: space-between;
+      min-width: 120px;
     }
   }
 }

--- a/src/utils/sharedFunctions.ts
+++ b/src/utils/sharedFunctions.ts
@@ -1,3 +1,20 @@
+import { LibraryData } from "../interfaces";
+
+export const months = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December"
+];
+
 // Given a number x and a total number, calculate what percentage x is of the total.
 // The total can be passed directly in as a number or a string containing a number, or can
 // be derived by adding up 1) the values in an array of numbers, 2) the values in an array of strings containing numbers,
@@ -18,7 +35,6 @@ export function getPercentage(x: number, outOf: number | string | Array<string |
 }
 
 export function getMonth(timestamp: string): string {
-  const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
   return `${months[new Date(timestamp).getMonth()]}`;
 }
 
@@ -33,4 +49,8 @@ export function findYear(date: string, resultText?: string, backupText?: string)
   let year = date?.match(/20\d+/) && date.match(/20\d+/)[0];
   let formattedYear = ` (${year ? (resultText || "") + year : backupText})`;
   return [year, formattedYear];
+}
+
+export function hasLibraries(data: {[key: string]: LibraryData[]}): boolean {
+  return Object.values(data).some(x => x?.length > 0);
 }


### PR DESCRIPTION
Resolves https://jira.nypl.org/browse/SIMPLY-3304.  Adds a Monthly Data tab to the aggregate data section; it has the same remove/restore formatting option and copy button as the other tabs do.  It defaults to displaying a list of the libraries validated during the current month and year, but has dropdowns so that you can opt to view libraries from any other month/year combination.

![Screen Shot 2021-01-11 at 4 38 16 PM](https://user-images.githubusercontent.com/42178216/104241792-376b3880-542c-11eb-9fc6-326c338c89c5.png)
