### PR TITLE
Simply 3854/search form UI changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v1.4.15
+
+#### Updated
+
+- Updated SearchForm to display a loading message until results are returned.
+- Upgraded to v1.3.20 of the reusable components package.
+- Updated SearchForm tests to check for new behavior.
+
 ### v1.4.14
 
 #### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -4133,9 +4133,9 @@
       }
     },
     "library-simplified-reusable-components": {
-      "version": "1.3.19",
-      "resolved": "https://registry.npmjs.org/library-simplified-reusable-components/-/library-simplified-reusable-components-1.3.19.tgz",
-      "integrity": "sha512-4IcGK+PT8hl5YVUex9vCXRAGRXShYZt7F5uG21CMsFGIUsD6neROD+gdoOhU6wJQqjpuagnISEa/A4imhRVFww==",
+      "version": "1.3.20",
+      "resolved": "https://registry.npmjs.org/library-simplified-reusable-components/-/library-simplified-reusable-components-1.3.20.tgz",
+      "integrity": "sha512-YiuyaQH+171T/SBS6AWCz3etvx4sOwXwWuYiMP1kMcriHZmoww+dTcR4fLxQ0SshxG9w+LGqAQlGc0XpPuPTGg==",
       "requires": {
         "@nypl/dgx-svg-icons": "^0.3.9",
         "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-registry-admin",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "description": "Web Front-end for Library Simplified Circulation Manager Admin Interface",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@nypl/dgx-svg-icons": "^0.3.13",
     "bootstrap": "^3.3.6",
-    "library-simplified-reusable-components": "^1.3.19",
+    "library-simplified-reusable-components": "^1.3.20",
     "node-sass": "^4.14.1",
     "opds-web-client": "0.3.4",
     "prop-types": "^15.7.2",

--- a/src/components/LibrariesPage.tsx
+++ b/src/components/LibrariesPage.tsx
@@ -31,6 +31,7 @@ export interface LibrariesPageState {
   searchTerm: string;
   qa: boolean;
   filters: { [key: string]: any };
+  receivedSearchResults: boolean;
 }
 
 export interface LibrariesPageProps
@@ -57,6 +58,7 @@ export class LibrariesPage extends React.Component<
       searchTerm: "",
       qa: false,
       filters: { flipped: false, attributes: { "PLS ID": false } },
+      receivedSearchResults: false,
     };
   }
 
@@ -75,6 +77,7 @@ export class LibrariesPage extends React.Component<
         inputName="name"
         clear={!this.state.showAll ? this.clear : null}
         resultsCount={libraries && libraries.length}
+        receivedSearchResults={this.state.receivedSearchResults}
       />
     );
 
@@ -259,8 +262,14 @@ export class LibrariesPage extends React.Component<
       showAll: false,
       searchTerm: data.get("name") as string,
       filters: this.state.filters,
+      receivedSearchResults: false,
     });
-    await this.props.search(data);
+    try {
+      await this.props.search(data);
+    } catch (e) {
+      console.error(`No results found for '${this.state.searchTerm}'.`);
+    }
+    this.setState({ receivedSearchResults: true });
   }
 
   async clear() {

--- a/src/components/LibrariesPage.tsx
+++ b/src/components/LibrariesPage.tsx
@@ -267,7 +267,7 @@ export class LibrariesPage extends React.Component<
     try {
       await this.props.search(data);
     } catch (e) {
-      console.error("There was an error finding search results:", e);
+      console.warn("There was an error finding search results:", e);
     }
     this.setState({ searchCompleted: true });
   }

--- a/src/components/LibrariesPage.tsx
+++ b/src/components/LibrariesPage.tsx
@@ -31,7 +31,7 @@ export interface LibrariesPageState {
   searchTerm: string;
   qa: boolean;
   filters: { [key: string]: any };
-  receivedSearchResults: boolean;
+  searchCompleted: boolean;
 }
 
 export interface LibrariesPageProps
@@ -58,7 +58,7 @@ export class LibrariesPage extends React.Component<
       searchTerm: "",
       qa: false,
       filters: { flipped: false, attributes: { "PLS ID": false } },
-      receivedSearchResults: false,
+      searchCompleted: false,
     };
   }
 
@@ -77,7 +77,7 @@ export class LibrariesPage extends React.Component<
         inputName="name"
         clear={!this.state.showAll ? this.clear : null}
         resultsCount={libraries && libraries.length}
-        receivedSearchResults={this.state.receivedSearchResults}
+        searchCompleted={this.state.searchCompleted}
       />
     );
 
@@ -262,14 +262,14 @@ export class LibrariesPage extends React.Component<
       showAll: false,
       searchTerm: data.get("name") as string,
       filters: this.state.filters,
-      receivedSearchResults: false,
+      searchCompleted: false,
     });
     try {
       await this.props.search(data);
     } catch (e) {
-      console.error(`No results found for '${this.state.searchTerm}'.`);
+      console.error("There was an error finding search results:", e);
     }
-    this.setState({ receivedSearchResults: true });
+    this.setState({ searchCompleted: true });
   }
 
   async clear() {

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -119,16 +119,3 @@ export default class SearchForm extends React.Component<
     return message;
   }
 }
-
-// if (this.props.resultsCount) {
-//   let resultsNumber = `${this.props.resultsCount} ${
-//     this.props.resultsCount > 1 ? "results" : "result"
-//   }`;
-//   message[
-//     "success"
-//   ] = `Displaying ${resultsNumber} for "${this.props.term}":`;
-// } else if (!this.props.receivedSearchResults) {
-//   message["loading"] = "Loading...";
-// } else {
-//   message["error"] = `No results found for "${this.props.term}".`;
-// }

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -1,12 +1,17 @@
 import * as React from "react";
-import { Panel, Button, Form, Input } from "library-simplified-reusable-components";
+import {
+  Panel,
+  Button,
+  Form,
+  Input,
+} from "library-simplified-reusable-components";
 import { SearchIcon } from "@nypl/dgx-svg-icons";
-
 
 export interface SearchFormOwnProps {
   search: (data: FormData) => void;
   text: string;
   inputName: string;
+  receivedSearchResults?: boolean;
   clear?: () => any;
   term?: string;
   resultsCount?: number;
@@ -17,7 +22,10 @@ export interface SearchFormState {
 }
 
 /** The search box at the top of the list of libraries. */
-export default class SearchForm extends React.Component<SearchFormOwnProps, SearchFormState> {
+export default class SearchForm extends React.Component<
+  SearchFormOwnProps,
+  SearchFormState
+> {
   constructor(props: SearchFormOwnProps) {
     super(props);
     this.updateSearchTerm = this.updateSearchTerm.bind(this);
@@ -45,23 +53,29 @@ export default class SearchForm extends React.Component<SearchFormOwnProps, Sear
         ref="form-component"
         onSubmit={this.props.search}
         content={input}
-        buttonContent={<span>Search <SearchIcon /></span>}
+        buttonContent={
+          <span>
+            Search <SearchIcon />
+          </span>
+        }
         className="search-form inline"
         disableButton={!this.state.searchTerm.length}
         successText={message["success"]}
         errorText={message["error"]}
+        loadingText={message["loading"]}
       />
     );
 
     let clearButton = null;
     if (this.props.clear) {
-      clearButton =
+      clearButton = (
         <Button
           key="form-button"
           className="left-align inverted"
           callback={this.clear}
           content="Clear search"
-        />;
+        />
+      );
     }
 
     return (
@@ -90,12 +104,31 @@ export default class SearchForm extends React.Component<SearchFormOwnProps, Sear
     if (!this.props.term) {
       return message;
     }
-    if (this.props.resultsCount) {
-      let resultsNumber = `${this.props.resultsCount} ${this.props.resultsCount > 1 ? "results" : "result"}`;
-      message["success"] = `Displaying ${resultsNumber} for ${this.props.term}:`;
+    if (!this.props.receivedSearchResults) {
+      message["loading"] = "Loading...";
+    } else if (this.props.resultsCount) {
+      let resultsNumber = `${this.props.resultsCount} ${
+        this.props.resultsCount > 1 ? "results" : "result"
+      }`;
+      message[
+        "success"
+      ] = `Displaying ${resultsNumber} for '${this.props.term}':`;
     } else {
-      message["error"] = `No results found for ${this.props.term}.`;
+      message["error"] = `No results found for '${this.props.term}'.`;
     }
     return message;
   }
 }
+
+// if (this.props.resultsCount) {
+//   let resultsNumber = `${this.props.resultsCount} ${
+//     this.props.resultsCount > 1 ? "results" : "result"
+//   }`;
+//   message[
+//     "success"
+//   ] = `Displaying ${resultsNumber} for "${this.props.term}":`;
+// } else if (!this.props.receivedSearchResults) {
+//   message["loading"] = "Loading...";
+// } else {
+//   message["error"] = `No results found for "${this.props.term}".`;
+// }

--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -11,7 +11,7 @@ export interface SearchFormOwnProps {
   search: (data: FormData) => void;
   text: string;
   inputName: string;
-  receivedSearchResults?: boolean;
+  searchCompleted?: boolean;
   clear?: () => any;
   term?: string;
   resultsCount?: number;
@@ -104,7 +104,7 @@ export default class SearchForm extends React.Component<
     if (!this.props.term) {
       return message;
     }
-    if (!this.props.receivedSearchResults) {
+    if (!this.props.searchCompleted) {
       message["loading"] = "Loading...";
     } else if (this.props.resultsCount) {
       let resultsNumber = `${this.props.resultsCount} ${
@@ -112,9 +112,9 @@ export default class SearchForm extends React.Component<
       }`;
       message[
         "success"
-      ] = `Displaying ${resultsNumber} for '${this.props.term}':`;
+      ] = `Displaying ${resultsNumber} for "${this.props.term}":`;
     } else {
-      message["error"] = `No results found for '${this.props.term}'.`;
+      message["error"] = `No results found for "${this.props.term}".`;
     }
     return message;
   }

--- a/src/components/__tests__/LibrariesPage-test.tsx
+++ b/src/components/__tests__/LibrariesPage-test.tsx
@@ -131,8 +131,31 @@ describe("LibrariesPage", () => {
       .find("input")
       .simulate("change", { target: { value: "test_search_term" } });
     wrapper.find(".panel-info form .btn").simulate("click");
-
     expect(wrapper.state()["showAll"]).to.be.false;
+  });
+
+  it("should set searchCompleted state correctly before and after search", async () => {
+    expect(wrapper.state()["searchCompleted"]).to.be.false;
+    wrapper
+      .find(".panel-info")
+      .find("input")
+      .simulate("change", { target: { value: "test_search_term" } });
+    wrapper.find(".panel-info form .btn").simulate("click");
+    expect(wrapper.state()["searchCompleted"]).to.be.false;
+    setTimeout(
+      () => expect(wrapper.state()["searchCompleted"]).to.be.true,
+      2000
+    );
+    wrapper
+      .find(".panel-info")
+      .find("input")
+      .simulate("change", { target: { value: "test_search_term" } });
+    wrapper.find(".panel-info form .btn").simulate("click");
+    expect(wrapper.state()["searchCompleted"]).to.be.false;
+    setTimeout(
+      () => expect(wrapper.state()["searchCompleted"]).to.be.true,
+      2000
+    );
   });
 
   it("shouldn't display QA search results unless in QA mode", async () => {

--- a/src/components/__tests__/SearchForm-test.tsx
+++ b/src/components/__tests__/SearchForm-test.tsx
@@ -17,6 +17,7 @@ describe("SearchForm", () => {
         search={search}
         text="Here is a search form!"
         inputName="testing"
+        searchCompleted={false}
       />
     );
   });
@@ -52,12 +53,17 @@ describe("SearchForm", () => {
   });
 
   it("should call search", () => {
+    expect(wrapper.props()["searchCompleted"]).to.be.false;
     let form = wrapper.find(Form);
     let formSubmit = Sinon.stub(form.instance(), "submit").callsFake(search);
     expect(search.callCount).to.equal(0);
     wrapper.setState({ searchTerm: "a string" });
     wrapper.find("button").simulate("click");
     expect(search.callCount).to.equal(1);
+    setTimeout(
+      () => expect(wrapper.props()["searchCompleted"]).to.be.true,
+      2000
+    );
     formSubmit.restore();
   });
 

--- a/src/components/__tests__/SearchForm-test.tsx
+++ b/src/components/__tests__/SearchForm-test.tsx
@@ -1,3 +1,4 @@
+/** eslint quotes "double", {"allowTemplateLiterals: true"} */
 import { expect } from "chai";
 import * as Sinon from "sinon";
 import * as Enzyme from "enzyme";
@@ -89,12 +90,12 @@ describe("SearchForm", () => {
     wrapper.setProps({
       term: "Test search term",
       resultsCount: 0,
-      receivedSearchResults: false,
+      searchCompleted: false,
     });
     loading = wrapper.find(".alert-loading");
     expect(loading.length).to.equal(1);
     wrapper.setProps({
-      receivedSearchResults: true,
+      searchCompleted: true,
     });
     loading = wrapper.find(".alert-loading");
     expect(loading.length).to.equal(0);
@@ -106,18 +107,18 @@ describe("SearchForm", () => {
     wrapper.setProps({
       term: "Test search term",
       resultsCount: 1,
-      receivedSearchResults: true,
+      searchCompleted: true,
     });
     success = wrapper.find(".alert-success");
     expect(success.length).to.equal(1);
     expect(success.text()).to.equal(
-      "Displaying 1 result for 'Test search term':"
+      `Displaying 1 result for "Test search term":`
     );
     wrapper.setProps({ resultsCount: 2 });
     success = wrapper.find(".alert-success");
     expect(success.length).to.equal(1);
     expect(success.text()).to.equal(
-      "Displaying 2 results for 'Test search term':"
+      `Displaying 2 results for "Test search term":`
     );
   });
 
@@ -127,11 +128,11 @@ describe("SearchForm", () => {
     wrapper.setProps({
       term: "Test search term",
       resultsCount: 0,
-      receivedSearchResults: true,
+      searchCompleted: true,
     });
     error = wrapper.find(".alert-danger");
     expect(error.length).to.equal(1);
-    expect(error.text()).to.equal("No results found for 'Test search term'.");
+    expect(error.text()).to.equal(`No results found for "Test search term".`);
   });
 
   it("should clear the input field when the clear button is clicked", () => {

--- a/src/components/__tests__/SearchForm-test.tsx
+++ b/src/components/__tests__/SearchForm-test.tsx
@@ -23,7 +23,9 @@ describe("SearchForm", () => {
   it("should display a panel containing a form with an input box and a button", () => {
     let panel = wrapper.find(".panel-info");
     expect(panel.length).to.equal(1);
-    expect(panel.find(".panel-title").text()).to.equal("Here is a search form!");
+    expect(panel.find(".panel-title").text()).to.equal(
+      "Here is a search form!"
+    );
     let form = panel.find(Form);
     expect(form.length).to.equal(1);
     expect(form.prop("onSubmit")).to.equal(wrapper.prop("search"));
@@ -41,7 +43,7 @@ describe("SearchForm", () => {
     expect(spyUpdate.callCount).to.equal(0);
     expect(wrapper.state()["searchTerm"]).to.equal("");
     let input = wrapper.find("input");
-    input.simulate("change", {target: {value: "test_search_term"}});
+    input.simulate("change", { target: { value: "test_search_term" } });
     expect(spyUpdate.callCount).to.equal(1);
     expect(spyUpdate.args[0][0].target.value).to.equal("test_search_term");
     expect(wrapper.state()["searchTerm"]).to.equal("test_search_term");
@@ -81,26 +83,55 @@ describe("SearchForm", () => {
     expect(clear.callCount).to.equal(1);
   });
 
+  it("should show a loading message before displaying a results message", () => {
+    let loading = wrapper.find(".alert-loading");
+    expect(loading.length).to.equal(0);
+    wrapper.setProps({
+      term: "Test search term",
+      resultsCount: 0,
+      receivedSearchResults: false,
+    });
+    loading = wrapper.find(".alert-loading");
+    expect(loading.length).to.equal(1);
+    wrapper.setProps({
+      receivedSearchResults: true,
+    });
+    loading = wrapper.find(".alert-loading");
+    expect(loading.length).to.equal(0);
+  });
+
   it("should optionally show a success message", () => {
     let success = wrapper.find(".alert-success");
     expect(success.length).to.equal(0);
-    wrapper.setProps({ term: "Test search term", resultsCount: 1 });
+    wrapper.setProps({
+      term: "Test search term",
+      resultsCount: 1,
+      receivedSearchResults: true,
+    });
     success = wrapper.find(".alert-success");
     expect(success.length).to.equal(1);
-    expect(success.text()).to.equal("Displaying 1 result for Test search term:");
+    expect(success.text()).to.equal(
+      "Displaying 1 result for 'Test search term':"
+    );
     wrapper.setProps({ resultsCount: 2 });
     success = wrapper.find(".alert-success");
     expect(success.length).to.equal(1);
-    expect(success.text()).to.equal("Displaying 2 results for Test search term:");
+    expect(success.text()).to.equal(
+      "Displaying 2 results for 'Test search term':"
+    );
   });
 
   it("should optionally show an error message", () => {
     let error = wrapper.find(".alert-danger");
     expect(error.length).to.equal(0);
-    wrapper.setProps({ term: "Test search term", resultsCount: 0 });
+    wrapper.setProps({
+      term: "Test search term",
+      resultsCount: 0,
+      receivedSearchResults: true,
+    });
     error = wrapper.find(".alert-danger");
     expect(error.length).to.equal(1);
-    expect(error.text()).to.equal("No results found for Test search term.");
+    expect(error.text()).to.equal("No results found for 'Test search term'.");
   });
 
   it("should clear the input field when the clear button is clicked", () => {


### PR DESCRIPTION
**Change**
- Adjusted SearchForm component to show loading message before results are returned.

**Reason**
- Before this change, SearchForm would return an error message even with valid search terms if the results hadn't yet come back from the server. This made for a confusing experience for the user.

**Tests**
- Adjusted SearchForm tests to account for this new behavior.
- All SearchForm tests are passing.