### PR TITLE
Added descriptions of libraries to seed data and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - SIMPLY-4066: Install Reservoir (NYPL Design System) and use components to build UI.
 - SIMPLY-4126: Fix bug where "Registry Stage" dropdown was showing "testing" when it should have shown "canceled."
 - SIMPLY-4125: Add patron counts to simple list view.
+- SIMPLY-4172: Add library description to library details.
 
 ## 1.4.15
 

--- a/data/libraries.ts
+++ b/data/libraries.ts
@@ -4,6 +4,7 @@ export interface LibrariesData {
   uuid: string;
   basic_info: {
     name: string;
+    description: string;
     short_name: string;
     number_of_patrons: string;
   };
@@ -29,6 +30,7 @@ const libraries: LibrariesData[] = [
     uuid: '1',
     basic_info: {
       name: 'Acton Public Library',
+      description: 'Serving Old Saybrook, CT',
       short_name: 'CTACTN',
       number_of_patrons: '9',
     },
@@ -53,6 +55,7 @@ const libraries: LibrariesData[] = [
     uuid: '2',
     basic_info: {
       name: 'Ak-Chin Indian Community Library, AZ',
+      description: 'Serving the needs of library users in Arizona',
       short_name: 'LVYZVC',
       number_of_patrons: '5',
     },
@@ -78,6 +81,7 @@ const libraries: LibrariesData[] = [
     uuid: '3',
     basic_info: {
       name: 'Alameda County Library',
+      description: 'Infinite possibilities',
       short_name: 'CALMDA',
       number_of_patrons: '1839',
     },
@@ -102,6 +106,8 @@ const libraries: LibrariesData[] = [
     uuid: '4',
     basic_info: {
       name: 'Alicia Salinas City of Alice Public Library, TX',
+      description:
+        'Serving the needs of library users in Jim Wells County, Texas',
       short_name: 'JEVRCG',
       number_of_patrons: '2',
     },
@@ -127,6 +133,7 @@ const libraries: LibrariesData[] = [
     uuid: '5',
     basic_info: {
       name: 'Allan Shivers Library & Museum, TX',
+      description: 'Serving Woodville, TX',
       short_name: 'JEVRCG',
       number_of_patrons: '0',
     },
@@ -151,6 +158,7 @@ const libraries: LibrariesData[] = [
     uuid: '6',
     basic_info: {
       name: 'Allegany County Library System',
+      description: 'Serving patrons of Maryland',
       short_name: 'JGSVTQ',
       number_of_patrons: '0',
     },
@@ -175,6 +183,7 @@ const libraries: LibrariesData[] = [
     uuid: '7',
     basic_info: {
       name: 'Allen Memorial Public Library, TX',
+      description: 'Open a book, open a mind. Knowledge is power.',
       short_name: 'UOVOCB',
       number_of_patrons: '9',
     },
@@ -199,6 +208,8 @@ const libraries: LibrariesData[] = [
     uuid: '8',
     basic_info: {
       name: 'Alpine Public Library, TX',
+      description:
+        'Building community, encouraging literacy, and promoting lifelong learning',
       short_name: 'NQSJGC',
       number_of_patrons: '59',
     },
@@ -223,6 +234,7 @@ const libraries: LibrariesData[] = [
     uuid: '9',
     basic_info: {
       name: 'Amarillo Public Library, TX',
+      description: 'Serving the patrons of Amarillo, TX',
       short_name: 'DTENGN',
       number_of_patrons: '78',
     },
@@ -247,6 +259,7 @@ const libraries: LibrariesData[] = [
     uuid: '10',
     basic_info: {
       name: 'Amigos Demo Library',
+      description: 'Unite Libraries for Action and Strength',
       short_name: 'WBDOBX',
       number_of_patrons: '22',
     },
@@ -271,6 +284,7 @@ const libraries: LibrariesData[] = [
     uuid: '11',
     basic_info: {
       name: 'Amigos Test Library Two',
+      description: 'Unite Libraries for Action and Strength',
       short_name: 'ZKVRQT',
       number_of_patrons: '0',
     },
@@ -295,6 +309,7 @@ const libraries: LibrariesData[] = [
     uuid: '12',
     basic_info: {
       name: 'Anacortes Public Library',
+      description: 'Serving Anacortes, WA',
       short_name: 'DCJROE',
       number_of_patrons: '0',
     },
@@ -319,6 +334,7 @@ const libraries: LibrariesData[] = [
     uuid: '13',
     basic_info: {
       name: 'Andrews County Library, TX',
+      description: 'Explore the world of books.',
       short_name: 'IDKEWG',
       number_of_patrons: '1',
     },
@@ -343,6 +359,7 @@ const libraries: LibrariesData[] = [
     uuid: '14',
     basic_info: {
       name: 'Anne Arundel Co. Public Library',
+      description: 'Educate. Enrich. Inspire.',
       short_name: 'MDANNE',
       number_of_patrons: '0',
     },
@@ -367,6 +384,7 @@ const libraries: LibrariesData[] = [
     uuid: '15',
     basic_info: {
       name: 'Ansonia Public Library',
+      description: 'Serving Ansonia, CT',
       short_name: 'CTANSO',
       number_of_patrons: '0',
     },

--- a/src/components/LibrariesList.tsx
+++ b/src/components/LibrariesList.tsx
@@ -20,7 +20,7 @@ const LibrariesList = ({ isSimpleList }: LibrariesListProps) => {
   };
 
   return (
-    <List noStyling type='ul'>
+    <>
       {isSimpleList ? (
         <Table
           columnHeaders={['Library Name', 'Patron Count']}
@@ -30,31 +30,33 @@ const LibrariesList = ({ isSimpleList }: LibrariesListProps) => {
           tableData={returnListData()}
         />
       ) : (
-        libraries.map((library) => {
-          const { name } = library.basic_info;
-          const { registry_stage: registryStage } = library.stages;
-          return (
-            <li key={name}>
-              <Accordion
-                accordionData={[
-                  {
-                    accordionType:
-                      registryStage === 'production'
-                        ? 'default'
-                        : registryStage === 'testing'
-                        ? 'warning'
-                        : 'error',
-                    label: name,
-                    panel: <LibraryDetails library={library} />,
-                  },
-                ]}
-                id={name}
-              />
-            </li>
-          );
-        })
+        <List noStyling type='ul'>
+          {libraries.map((library) => {
+            const { name } = library.basic_info;
+            const { registry_stage: registryStage } = library.stages;
+            return (
+              <li key={name}>
+                <Accordion
+                  accordionData={[
+                    {
+                      accordionType:
+                        registryStage === 'production'
+                          ? 'default'
+                          : registryStage === 'testing'
+                          ? 'warning'
+                          : 'error',
+                      label: name,
+                      panel: <LibraryDetails library={library} />,
+                    },
+                  ]}
+                  id={name}
+                />
+              </li>
+            );
+          })}
+        </List>
       )}
-    </List>
+    </>
   );
 };
 

--- a/src/components/LibraryDetails.tsx
+++ b/src/components/LibraryDetails.tsx
@@ -64,7 +64,7 @@ const LibraryDetails = ({ library }: LibraryDetailsProps) => {
               uuid={uuid}
               stage='libraryStage'
               value={libraryStage}
-              handleChange={setLibraryStage}
+              setLibraryStage={setLibraryStage}
             />
           </FormField>
           <FormField>
@@ -72,7 +72,7 @@ const LibraryDetails = ({ library }: LibraryDetailsProps) => {
               uuid={uuid}
               stage='registryStage'
               value={registryStage}
-              handleChange={setRegistryStage}
+              setLibraryStage={setRegistryStage}
             />
           </FormField>
         </FormRow>

--- a/src/components/StageSelect.tsx
+++ b/src/components/StageSelect.tsx
@@ -4,14 +4,14 @@ import { Select } from '@nypl/design-system-react-components';
 import { LibraryStage } from './LibraryDetails';
 
 interface StageSelectProps {
-  handleChange: (stage: LibraryStage) => void;
+  setLibraryStage: React.Dispatch<React.SetStateAction<LibraryStage>>;
   stage: 'libraryStage' | 'registryStage';
   uuid: string;
   value: LibraryStage;
 }
 
 const StageSelect = ({
-  handleChange,
+  setLibraryStage,
   stage,
   uuid,
   value,
@@ -22,8 +22,8 @@ const StageSelect = ({
       labelText={stage === 'libraryStage' ? 'Library Stage' : 'Registry Stage'}
       name={stage}
       value={value}
-      onChange={(e) =>
-        handleChange((e.target as HTMLTextAreaElement).value as LibraryStage)
+      onChange={(e: React.FormEvent<Element>) =>
+        setLibraryStage((e.target as HTMLInputElement).value as LibraryStage)
       }
     >
       <option value='testing'>Testing</option>

--- a/src/components/__tests__/__snapshots__/AdminPage.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/AdminPage.test.tsx.snap
@@ -636,6 +636,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                   Acton Public Library
                                 </dd>
                                 <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Serving Old Saybrook, CT
+                                </dd>
+                                <dt>
                                   short_name
                                 </dt>
                                 <dd>
@@ -1163,6 +1169,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                 </dt>
                                 <dd>
                                   Ak-Chin Indian Community Library, AZ
+                                </dd>
+                                <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Serving the needs of library users in Arizona
                                 </dd>
                                 <dt>
                                   short_name
@@ -1694,6 +1706,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                   Alameda County Library
                                 </dd>
                                 <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Infinite possibilities
+                                </dd>
+                                <dt>
                                   short_name
                                 </dt>
                                 <dd>
@@ -2221,6 +2239,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                 </dt>
                                 <dd>
                                   Alicia Salinas City of Alice Public Library, TX
+                                </dd>
+                                <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Serving the needs of library users in Jim Wells County, Texas
                                 </dd>
                                 <dt>
                                   short_name
@@ -2752,6 +2776,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                   Allan Shivers Library & Museum, TX
                                 </dd>
                                 <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Serving Woodville, TX
+                                </dd>
+                                <dt>
                                   short_name
                                 </dt>
                                 <dd>
@@ -3279,6 +3309,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                 </dt>
                                 <dd>
                                   Allegany County Library System
+                                </dd>
+                                <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Serving patrons of Maryland
                                 </dd>
                                 <dt>
                                   short_name
@@ -3810,6 +3846,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                   Allen Memorial Public Library, TX
                                 </dd>
                                 <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Open a book, open a mind. Knowledge is power.
+                                </dd>
+                                <dt>
                                   short_name
                                 </dt>
                                 <dd>
@@ -4337,6 +4379,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                 </dt>
                                 <dd>
                                   Alpine Public Library, TX
+                                </dd>
+                                <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Building community, encouraging literacy, and promoting lifelong learning
                                 </dd>
                                 <dt>
                                   short_name
@@ -4868,6 +4916,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                   Amarillo Public Library, TX
                                 </dd>
                                 <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Serving the patrons of Amarillo, TX
+                                </dd>
+                                <dt>
                                   short_name
                                 </dt>
                                 <dd>
@@ -5395,6 +5449,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                 </dt>
                                 <dd>
                                   Amigos Demo Library
+                                </dd>
+                                <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Unite Libraries for Action and Strength
                                 </dd>
                                 <dt>
                                   short_name
@@ -5926,6 +5986,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                   Amigos Test Library Two
                                 </dd>
                                 <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Unite Libraries for Action and Strength
+                                </dd>
+                                <dt>
                                   short_name
                                 </dt>
                                 <dd>
@@ -6453,6 +6519,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                 </dt>
                                 <dd>
                                   Anacortes Public Library
+                                </dd>
+                                <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Serving Anacortes, WA
                                 </dd>
                                 <dt>
                                   short_name
@@ -6984,6 +7056,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                   Andrews County Library, TX
                                 </dd>
                                 <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Explore the world of books.
+                                </dd>
+                                <dt>
                                   short_name
                                 </dt>
                                 <dd>
@@ -7513,6 +7591,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                   Anne Arundel Co. Public Library
                                 </dd>
                                 <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Educate. Enrich. Inspire.
+                                </dd>
+                                <dt>
                                   short_name
                                 </dt>
                                 <dd>
@@ -8040,6 +8124,12 @@ exports[`AdminPage Snapshot renders the UI snapshot correctly 1`] = `
                                 </dt>
                                 <dd>
                                   Ansonia Public Library
+                                </dd>
+                                <dt>
+                                  description
+                                </dt>
+                                <dd>
+                                  Serving Ansonia, CT
                                 </dd>
                                 <dt>
                                   short_name

--- a/src/components/__tests__/__snapshots__/LibraryDetails.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/LibraryDetails.test.tsx.snap
@@ -424,6 +424,12 @@ Array [
                 Acton Public Library
               </dd>
               <dt>
+                description
+              </dt>
+              <dd>
+                Serving Old Saybrook, CT
+              </dd>
+              <dt>
                 short_name
               </dt>
               <dd>


### PR DESCRIPTION
- Added descriptions to library accordions per [SIMPLY-4127.](https://jira.nypl.org/browse/SIMPLY-4127).
- Fixed issue where a <Table/> was being rendered inside a <List/> and causing a warning.
- Fixed type for useState function.