### PR TITLE
SIMPLY-4194: add error boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - SIMPLY-4162: Make POST requests when a user changes a library's stage.
 - SIMPLY-4184: Add QA testing checklist to README.
 - SIMPLY-4068: Add error handling for fetch requests.
+- SIMPLY-4194: Add a top-level error boundary.
 
 ## 1.4.15
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@nypl/design-system-react-components": "^1.0.8",
         "js-cookie": "^3.0.1",
         "react": "^18.1.0",
-        "react-dom": "^18.1.0"
+        "react-dom": "^18.1.0",
+        "react-error-boundary": "^3.1.4"
       },
       "devDependencies": {
         "@parcel/transformer-sass": "^2.6.0",
@@ -13718,6 +13719,21 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
@@ -26287,6 +26303,14 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@nypl/design-system-react-components": "^1.0.8",
     "js-cookie": "^3.0.1",
     "react": "^18.1.0",
-    "react-dom": "^18.1.0"
+    "react-dom": "^18.1.0",
+    "react-error-boundary": "^3.1.4"
   },
   "devDependencies": {
     "@parcel/transformer-sass": "^2.6.0",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,14 +9,14 @@ import { LibrariesProvider } from '../context/librariesContext';
 
 export function App() {
   return (
-    <DSProvider>
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <DSProvider>
         <TokenProvider>
           <LibrariesProvider>
             <RegistryAdmin />
           </LibrariesProvider>
         </TokenProvider>
-      </ErrorBoundary>
-    </DSProvider>
+      </DSProvider>
+    </ErrorBoundary>
   );
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { DSProvider } from '@nypl/design-system-react-components';
+import { ErrorBoundary } from 'react-error-boundary';
 
+import ErrorFallback from './ErrorFallback';
 import RegistryAdmin from './RegistryAdmin';
 import { TokenProvider } from '../context/tokenContext';
 import { LibrariesProvider } from '../context/librariesContext';
@@ -8,11 +10,13 @@ import { LibrariesProvider } from '../context/librariesContext';
 export function App() {
   return (
     <DSProvider>
-      <TokenProvider>
-        <LibrariesProvider>
-          <RegistryAdmin />
-        </LibrariesProvider>
-      </TokenProvider>
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <TokenProvider>
+          <LibrariesProvider>
+            <RegistryAdmin />
+          </LibrariesProvider>
+        </TokenProvider>
+      </ErrorBoundary>
     </DSProvider>
   );
 }

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Notification } from '@nypl/design-system-react-components';
+
+const ErrorFallback = ({ error }: { error: Error }) => {
+  return (
+    <Notification
+      id='error-fallback'
+      notificationContent={error.message}
+      notificationHeading='Something went wrong:'
+      notificationType='warning'
+    />
+  );
+};
+
+export default ErrorFallback;

--- a/src/components/__tests__/ErrorFallback.test.tsx
+++ b/src/components/__tests__/ErrorFallback.test.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ErrorBoundary } from 'react-error-boundary';
+import ErrorFallback from '../ErrorFallback';
+
+describe('Error Boundary', () => {
+  // Mocking console.error so that the errors thrown by the ThrowError
+  // component below don't get logged to the console.
+  beforeEach(() => {
+    jest.spyOn(console, 'error');
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    (console.error as jest.Mock).mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    (console.error as jest.Mock).mockRestore();
+  });
+  test('Error Boundary', () => {
+    const ThrowError = () => {
+      throw new Error('There was a problem fetching the libraries.');
+    };
+    render(
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <ThrowError />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/there was a problem fetching/i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Adds library react-error-boundary, which eliminates the need to create a React Error Boundary class component and catches a wider variety of errors
- Adds fallback component, `ErrorFallback` which utilizes the DS `Notification` component to display the error message
- Adds tests