### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED CHANGES
 
+## 2.0.0
+
 - SIMPLY-4065: Convert application to a new parcel build
 - SIMPLY-4066: Install Reservoir (NYPL Design System) and use components to build UI.
 - SIMPLY-4126: Fix bug where "Registry Stage" dropdown was showing "testing" when it should have shown "canceled."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "registry_admin",
-  "version": "1.4.15",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "registry_admin",
-      "version": "1.4.15",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@nypl/design-system-react-components": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registry_admin",
-  "version": "1.4.15",
+  "version": "2.0.0",
   "description": "admin UI for registered libraries",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The prod subdomain has been created and is live at https://libraryregistry-admin.librarysimplified.org/. Let's make a prod release!