### PR TITLE
Fix library endpoint to be `/libraries/qa` even in prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED CHANGES
 
+## 2.0.2
+
+- Use /libraries/qa endpoint to fetch libraries on production
+
 ## 2.0.1
 
 - Hotfix point QA library endpoint to production

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "registry_admin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "registry_admin",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@nypl/design-system-react-components": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "registry_admin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "admin UI for registered libraries",
   "repository": {
     "type": "git",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,5 @@
 export const LOGIN = `${process.env.REGISTRY_API_DOMAIN}/log_in/jwt`;
 export const REFRESH = `${process.env.REGISTRY_API_DOMAIN}/refresh_token`;
-export const FETCH_LIBRARIES = process.env.REGISTRY_API_DOMAIN?.includes('qa')
-  ? `${process.env.REGISTRY_API_DOMAIN}/libraries/qa`
-  : `${process.env.REGISTRY_API_DOMAIN}/libraries`;
+// despite this endpoint including /qa, it is indeed supposed to be used in production :'(
+export const FETCH_LIBRARIES = `${process.env.REGISTRY_API_DOMAIN}/libraries/qa`;
 export const UPDATE_LIBRARY_STAGE = `${process.env.REGISTRY_API_DOMAIN}/libraries/registration`;


### PR DESCRIPTION
Risa noticed an issue with the library registry in prod, where it wasn't showing the full list of libraries. She said it was working as expected on the old deployment (https://libraryregistry.librarysimplified.org/admin) so I checked the endpoint being called there, and it was `/libraries/qa`. So I guess we should be calling `/libraries/qa` even in production 😵‍💫 